### PR TITLE
Fix test.robot : change wrong keyword Get Value by Get Value From Set

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ test.robot
         Log   This part is critical section
         Release Lock   MyLock
         ${valuesetname}=    Acquire Value Set
-        ${host}=   Get Value   HOST
+        ${host}=   Get Value From Set   HOST
         ${username}=     Get Value From Set   USERNAME
         ${password}=     Get Value From Set   PASSWORD
         Log   Do something with the values (for example access host with username and password)


### PR DESCRIPTION
Hi Mikko.
Thanks for this great tool that indeed seems awesome :)
I just started testing it few days ago and encountered several issues.
a) i suggest a fix cause the exemple (test.robot) seems to contains a typo ^^
b) Working on a Mac with Robot 2.8.5 (Python 2.7.x), I noticed that the test fails, due to the fact that, in the test.robot files, HOST, USERNAME and PASSWORD are upper case... If I siwtch them to lower case, the test passes : any idea about this trouble ?
c) I noticed that launching pabot, the option "--pabotlib" seems mandatory :) : did I miss anything ?

Thanks for your help / information.
Regards
JCDeville
