### PR TITLE
Fixed README.md example test case.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ test.robot
         Log   This part is critical section
         Release Lock   MyLock
         ${valuesetname}=    Acquire Value Set
-        ${host}=   Get Value From Set   HOST
-        ${username}=     Get Value From Set   USERNAME
-        ${password}=     Get Value From Set   PASSWORD
+        ${host}=   Get Value From Set   host
+        ${username}=     Get Value From Set   username
+        ${password}=     Get Value From Set   password
         Log   Do something with the values (for example access host with username and password)
         Release Value Set
         Log   After value set release others can obtain the variable values


### PR DESCRIPTION
At least on windows and linux the
README.md example test case does not work.
The Get Value From Set keywords requires
that the value is written in lower case.