### PR TITLE
Got rid of still running message

### DIFF
--- a/pabot/pabot.py
+++ b/pabot/pabot.py
@@ -86,8 +86,8 @@ def _run(cmd, stderr, stdout, suite_name, verbose):
         rc = process.poll()
         time.sleep(0.1)
         elapsed += 1
-        if elapsed % 150 == 0:
-            _write('[PID:%s] still running %s after %s seconds' % (process.pid, suite_name, elapsed / 10.0))
+        #if elapsed % 150 == 0:
+           # _write('[PID:%s] still running %s after %s seconds' % (process.pid, suite_name, elapsed / 10.0))
     return process, rc
 
 def _execution_failed_message(suite_name, rc, verbose):


### PR DESCRIPTION
Wanted to get rid of the "Still running message". It kept showing up and I thought it was a bit redundant and doesn't really tell us that much of any good info. You can change it to the master branch as well if you want, I did to my fork and I felt it was helpful :) thanks