### PR TITLE
Fix issue #52

### DIFF
--- a/pabot/result_merger.py
+++ b/pabot/result_merger.py
@@ -19,8 +19,9 @@
 from robot.api import ExecutionResult
 from robot.conf import RebotSettings
 from robot.result.executionresult import CombinedResult
-from robot.result.testsuite import TestSuite
+from robot.result import TestSuite
 from robot.model import SuiteVisitor
+
 
 class ResultMerger(SuiteVisitor):
 


### PR DESCRIPTION
Fix issue #52 with module import when using pabot with Robot Framework 3.0 and one pep8 related fix (two blank lines before class).
Tested with RF versions 2.9.2 and 3.0b1