### PR TITLE
Fix for Issue #56

### DIFF
--- a/pabot/pabot.py
+++ b/pabot/pabot.py
@@ -147,6 +147,7 @@ class GatherSuiteNames(ResultVisitor):
 
 def get_suite_names(output_file):
     if not os.path.isfile(output_file):
+       print "get_suite_names: output_file='%s' does not exist" % output_file
        return []
     try:
        e = ExecutionResult(output_file)
@@ -154,6 +155,7 @@ def get_suite_names(output_file):
        e.visit(gatherer)
        return gatherer.result
     except:
+       print "Exception in get_suite_names!"
        return []
 
 def _parse_args(args):
@@ -215,6 +217,7 @@ def _options_for_dryrun(options, outs_dir):
     else:
         options['runmode'] = 'DryRun'
     options['output'] = 'suite_names.xml'
+    options['timestampoutputs'] = False     # --timestampoutputs is not compatible with hard-coded suite_names.xml above
     options['outputdir'] = outs_dir
     options['stdout'] = StringIO()
     options['stderr'] = StringIO()


### PR DESCRIPTION
Fix consists of:
1. Forcing timestampoutputs to False when doing the DryRun step of pabot
2. Adding print statements to notify users why get_suite_names returns
an empty list (in case some other issue causes a bad-named XML file like
this one did)