### PR TITLE
fix issue #83

### DIFF
--- a/pabot/pabot.py
+++ b/pabot/pabot.py
@@ -280,7 +280,8 @@ def _parse_args(args):
             args = args[2:]
     options, datasources = ArgumentParser(USAGE,
                                           auto_pythonpath=False,
-                                          auto_argumentfile=False).\
+                                          auto_argumentfile=False,
+                                          env_options='ROBOT_OPTIONS').\
         parse_args(args)
     if len(datasources) > 1 and options['name'] is None:
         options['name'] = 'Suites'


### PR DESCRIPTION
Hi
this is fix for variable ROBOT_OPTIONS only. As far as I can tell there is no need to pass names of other environment variables (they are handled internally by pybot and not passed as arguments to any methods).
ROBOT_INTERNAL_TRACES - will be inherited by subprocess.
ROBOT_SYSLOG_LEVEL - will be inherited by subprocess.
ROBOT_SYSLOG_FILE - will be inherited by subprocess, but here we have a problem - output file is overridden by each running pybot instance, and then by rebot (I guess when compiling merged output).
Honestly I'm not sure if anyone uses these variables to debug in "pabot" mode.
