### PR TITLE
fix missing screenshot path correction in 1st failing test

### DIFF
--- a/pabot/result_merger.py
+++ b/pabot/result_merger.py
@@ -41,7 +41,7 @@ class ResultMerger(SuiteVisitor):
     def merge(self, merged):
         try:
             merged.suite.visit(self)
-            self.errors.add(merged.errors)
+            if self.errors!=merged.errors: self.errors.add(merged.errors)
         except:
             print 'Error while merging result %s' % merged.source
             raise
@@ -126,7 +126,7 @@ def merge_groups(results, critical_tags, non_critical_tags, tests_root_name):
                                non_critical_tags).values():
         base = group[0]
         merger = ResultMerger(base, tests_root_name)
-        for out in group[1:]:
+        for out in group:
             merger.merge(out)
         merged.append(base)
     return merged


### PR DESCRIPTION
Now i found the reason, why merging with goup[0] was needed: if a test/suite fails with screenshot, then merging is needed to apply path corrections. I rolled back line 129, but then i need to avoid duplicate WARN msgs again. Thus i added check in line 44...