### PR TITLE
fix extra spaces + better parallelization

### DIFF
--- a/pabot/pabot.py
+++ b/pabot/pabot.py
@@ -488,7 +488,7 @@ def _parallel_execute(datasources, options, outs_dir, pabot_args, suite_names):
                             ((datasources, outs_dir, options, suite,
                               pabot_args['command'], pabot_args['verbose'], argfile)
                              for suite in suite_names
-                             for argfile in pabot_args['argumentfiles'] or [("", None)]))
+                             for argfile in pabot_args['argumentfiles'] or [("", None)]),1)
     pool.close()
     while not result.ready():
         # keyboard interrupt is executed in main thread

--- a/pabot/pabot.py
+++ b/pabot/pabot.py
@@ -156,7 +156,9 @@ def _make_id():
 
 def _run(cmd, stderr, stdout, suite_name, verbose, pool_id):
     timestamp = datetime.datetime.now()
+    # isinstance(cmd,list)==True
     cmd = ' '.join(cmd)
+    # isinstance(cmd,basestring if PY2 else str)==True
     if PY2:
         cmd = cmd.decode('utf-8').encode(SYSTEM_ENCODING)
     process = subprocess.Popen(cmd,
@@ -164,8 +166,7 @@ def _run(cmd, stderr, stdout, suite_name, verbose, pool_id):
                                stderr=stderr,
                                stdout=stdout)
     if verbose:
-        _write_with_id(process, pool_id, 'EXECUTING PARALLEL SUITE %s with command:\n%s' % (suite_name, ' '.join(cmd)),
-                       timestamp=timestamp)
+        _write_with_id(process, pool_id, 'EXECUTING PARALLEL SUITE %s with command:\n%s' % (suite_name, cmd),timestamp=timestamp)
     else:
         _write_with_id(process, pool_id, 'EXECUTING %s' % suite_name, timestamp=timestamp)
     return process, _wait_for_return_code(process, suite_name, pool_id)


### PR DESCRIPTION
1. Commit get rid of extra spaces in verbose mode.

2. Commit improves pabot parallelization using chunksize=1 instead of default.
Problematic was the unspecified chunksize when calling multiprocessing.pool.map_async. This function uses a default chunksize = round_up(suite_count / (processes * 4)).

Now: assume 9 testsuites S1, ..., S9 where execution times of S3 and S4 is 20sec and all others are fast.
If you run pabot with 2 processes p0 and p1 results in chunksize=2 and the list of 9 files is split into chunks:
[S1,S2] via p0 (fast)
[S3,S4] via p1 (slow)
All other chunks are processed via p0 fast.

The problem: When p0 finished all fast chunks, then p0 is idle while p1 is still running S3. S4 is not started on p0, because it is planned for p1 (chunked together with S3)!

Here is a log before this chunksize-fix, where pabot needs 42 secs:

2017-10-20 16:25:35.326290 [PID:1384] [0] EXECUTING Pabot Chunksize.S1
2017-10-20 16:25:35.327290 [PID:9688] [1] EXECUTING Pabot Chunksize.S3
2017-10-20 16:25:36.234313 [PID:1384] [0] PASSED Pabot Chunksize.S1 in 0.9 seconds
2017-10-20 16:25:36.238569 [PID:7396] [0] EXECUTING Pabot Chunksize.S2
2017-10-20 16:25:37.047773 [PID:7396] [0] PASSED Pabot Chunksize.S2 in 0.8 seconds
2017-10-20 16:25:37.054777 [PID:2076] [0] EXECUTING Pabot Chunksize.S5
2017-10-20 16:25:37.763677 [PID:2076] [0] PASSED Pabot Chunksize.S5 in 0.7 seconds
2017-10-20 16:25:37.768682 [PID:2528] [0] EXECUTING Pabot Chunksize.S6
2017-10-20 16:25:38.579894 [PID:2528] [0] PASSED Pabot Chunksize.S6 in 0.8 seconds
2017-10-20 16:25:38.585898 [PID:12944] [0] EXECUTING Pabot Chunksize.S7
2017-10-20 16:25:39.398868 [PID:12944] [0] PASSED Pabot Chunksize.S7 in 0.8 seconds
2017-10-20 16:25:39.405873 [PID:11580] [0] EXECUTING Pabot Chunksize.S8
2017-10-20 16:25:40.215472 [PID:11580] [0] PASSED Pabot Chunksize.S8 in 0.8 seconds
2017-10-20 16:25:40.221474 [PID:10220] [0] EXECUTING Pabot Chunksize.S9
2017-10-20 16:25:41.030263 [PID:10220] [0] PASSED Pabot Chunksize.S9 in 0.8 seconds
2017-10-20 16:25:50.395582 [PID:9688] [1] still running Pabot Chunksize.S3 after 15.0 seconds (next ping in 20.0 seconds)
2017-10-20 16:25:56.222405 [PID:9688] [1] PASSED Pabot Chunksize.S3 in 20.8 seconds
2017-10-20 16:25:56.228412 [PID:12448] [1] EXECUTING Pabot Chunksize.S4
2017-10-20 16:26:11.312275 [PID:12448] [1] still running Pabot Chunksize.S4 after 15.0 seconds (next ping in 20.0 seconds)
2017-10-20 16:26:17.042883 [PID:12448] [1] PASSED Pabot Chunksize.S4 in 20.7 seconds
Elapsed time: 0 minutes 42.333 seconds


And this is a new log, where pabot needs just 24 secs using chunksize=1:

2017-10-20 16:45:29.530327 [PID:2920] [0] EXECUTING Pabot Chunksize.S1
2017-10-20 16:45:29.530327 [PID:6168] [1] EXECUTING Pabot Chunksize.S2
2017-10-20 16:45:30.441103 [PID:2920] [0] PASSED Pabot Chunksize.S1 in 0.9 seconds
2017-10-20 16:45:30.441103 [PID:6168] [1] PASSED Pabot Chunksize.S2 in 0.9 seconds
2017-10-20 16:45:30.446105 [PID:11140] [1] EXECUTING Pabot Chunksize.S4
2017-10-20 16:45:30.446105 [PID:8524] [0] EXECUTING Pabot Chunksize.S3
2017-10-20 16:45:45.515452 [PID:11140] [1] still running Pabot Chunksize.S4 after 15.0 seconds (next ping in 20.0 seconds)
2017-10-20 16:45:45.519456 [PID:8524] [0] still running Pabot Chunksize.S3 after 15.0 seconds (next ping in 20.0 seconds)
2017-10-20 16:45:51.247296 [PID:8524] [0] PASSED Pabot Chunksize.S3 in 20.7 seconds
2017-10-20 16:45:51.252298 [PID:12520] [0] EXECUTING Pabot Chunksize.S5
2017-10-20 16:45:51.342360 [PID:11140] [1] PASSED Pabot Chunksize.S4 in 20.8 seconds
2017-10-20 16:45:51.347363 [PID:4584] [1] EXECUTING Pabot Chunksize.S6
2017-10-20 16:45:52.060460 [PID:12520] [0] PASSED Pabot Chunksize.S5 in 0.8 seconds
2017-10-20 16:45:52.065463 [PID:7524] [0] EXECUTING Pabot Chunksize.S7
2017-10-20 16:45:52.154525 [PID:4584] [1] PASSED Pabot Chunksize.S6 in 0.8 seconds
2017-10-20 16:45:52.159530 [PID:12284] [1] EXECUTING Pabot Chunksize.S8
2017-10-20 16:45:52.874040 [PID:7524] [0] PASSED Pabot Chunksize.S7 in 0.8 seconds
2017-10-20 16:45:52.877933 [PID:10688] [0] EXECUTING Pabot Chunksize.S9
2017-10-20 16:45:52.968095 [PID:12284] [1] PASSED Pabot Chunksize.S8 in 0.8 seconds
2017-10-20 16:45:53.686944 [PID:10688] [0] PASSED Pabot Chunksize.S9 in 0.8 seconds
Elapsed time: 0 minutes 24.754 seconds
