### PR TITLE
use UTF-8 encoding to support chinese character

### DIFF
--- a/pabot/pabot.py
+++ b/pabot/pabot.py
@@ -593,7 +593,7 @@ def _glob_escape(pathname):
 def _writer():
     while True:
         message = MESSAGE_QUEUE.get()
-        print(message)
+        print(message.encode("UTF-8"))
         sys.stdout.flush()
 
 


### PR DESCRIPTION
when run in docker container , raise UnicodeEncodeError
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 754, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/usr/lib/python2.7/site-packages/pabot/pabot.py", line 561, in _writer
    print message
UnicodeEncodeError: 'ascii' codec can't encode characters in position 80-81: ordinal not in range(128)