### PR TITLE
Remove the symbols '.' from the suites folder`s name that in the output folder, and shortened the name length that only remain the child suite`s name

### DIFF
--- a/pabot/pabot.py
+++ b/pabot/pabot.py
@@ -165,9 +165,13 @@ def _wait_for_return_code(process, suite_name, pool_id):
         if elapsed == ping_time:
             ping_interval += 50
             ping_time += ping_interval
-            _write_with_id(process, pool_id, 'still running %s after %s seconds '
-                   '(next ping in %s seconds)'
-                   % (suite_name, elapsed / 10.0, ping_interval / 10.0))
+            #_write_with_id(process, pool_id, 'still running %s after %s seconds '
+            #       '(next ping in %s seconds)'
+            #       % (suite_name, elapsed / 10.0, ping_interval / 10.0))
+        if elapsed >= 3600:
+            CTRL_C_PRESSED
+            rc = 255
+
     return rc, elapsed / 10.0
 
 

--- a/pabot/pabot.py
+++ b/pabot/pabot.py
@@ -168,8 +168,6 @@ def _wait_for_return_code(process, suite_name, pool_id):
             _write_with_id(process, pool_id, 'still running %s after %s seconds '
                    '(next ping in %s seconds)'
                    % (suite_name, elapsed / 10.0, ping_interval / 10.0))
-
-
     return rc, elapsed / 10.0
 
 

--- a/pabot/pabot.py
+++ b/pabot/pabot.py
@@ -107,7 +107,7 @@ def execute_and_wait_with(args):
     datasources, outs_dir, options, suite_name, command, verbose, (argfile_index, argfile) = args
     datasources = [d.encode('utf-8') if isinstance(d, unicode) else d
                    for d in datasources]
-    mini_suiteName= re.sub(' ','-',(suite_name.split('.')[-1])
+    mini_suiteName= re.sub(' ','-',(suite_name.split('.')[-1]) + time.strftime("%H%M%S", time.localtime())
     outs_dir = os.path.join(outs_dir, argfile_index, mini_suiteName)
     pool_id = _make_id()
     cmd = command + _options_for_custom_executor(options,

--- a/pabot/pabot.py
+++ b/pabot/pabot.py
@@ -107,7 +107,8 @@ def execute_and_wait_with(args):
     datasources, outs_dir, options, suite_name, command, verbose, (argfile_index, argfile) = args
     datasources = [d.encode('utf-8') if isinstance(d, unicode) else d
                    for d in datasources]
-    outs_dir = os.path.join(outs_dir, argfile_index, suite_name)
+    mini_suiteName= re.sub(' ','-',(suite_name.split('.')[-1])
+    outs_dir = os.path.join(outs_dir, argfile_index, mini_suiteName)
     pool_id = _make_id()
     cmd = command + _options_for_custom_executor(options,
                                                  outs_dir,

--- a/pabot/pabot.py
+++ b/pabot/pabot.py
@@ -165,12 +165,10 @@ def _wait_for_return_code(process, suite_name, pool_id):
         if elapsed == ping_time:
             ping_interval += 50
             ping_time += ping_interval
-            #_write_with_id(process, pool_id, 'still running %s after %s seconds '
-            #       '(next ping in %s seconds)'
-            #       % (suite_name, elapsed / 10.0, ping_interval / 10.0))
-        if elapsed >= 3600:
-            CTRL_C_PRESSED
-            rc = 255
+            _write_with_id(process, pool_id, 'still running %s after %s seconds '
+                   '(next ping in %s seconds)'
+                   % (suite_name, elapsed / 10.0, ping_interval / 10.0))
+
 
     return rc, elapsed / 10.0
 


### PR DESCRIPTION
 If I execute the multiple testsuites that have some child testsuites at same time , the outputs folder`s name is too long to be recognized.
The default testsuites`s folder name within the many symbols '.' ; it is so confused and hard to be managed.
I just keep the last suite name as the output`s folder name, with this method the name of each folder (each layer) become shorten with any symbol  '.'