### PR TITLE
Fixed empty settings and variables errors

### DIFF
--- a/pabot/pabot.py
+++ b/pabot/pabot.py
@@ -412,7 +412,6 @@ def _with_modified_robot():
                         populator.add(cells)
                         first = True
                     elif first:
-                        populator.add(['', 'No Operation'])
                         first = False
             populator.eof()
 


### PR DESCRIPTION
If you're using new line as separator in settings and variables sections then current parser adds these empty lines to robot populator. This leads to errors in stderr:
`Error in file 'test.robot': Non-existing setting ''`
`Error in file 'test.robot': Setting variable '' failed: Invalid variable name ''`
RobotFramework are trying to parse empty lines as settings and variables which leads to filling the log with these trash errors.
It's annoying to scroll down all these useless messages to see an actual error (especially if there are hundred of tests).