### PR TITLE
Verify status code before thread shutdown

### DIFF
--- a/tests/test_pabot.py
+++ b/tests/test_pabot.py
@@ -71,8 +71,8 @@ class PabotTests(unittest.TestCase):
                                             pabot._now(),
                                             pabot._get_suite_root_name(
                                                 suite_names))
-        pabot._stop_remote_library(lib_process)
         self.assertEqual(5, result_code)
+        pabot._stop_remote_library(lib_process)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Testing pabot asks for a kill on rpc process of PabotLib, which is changing the result_code from the suite running. I tried to lookup for changes in SimpleXMLRPCServer, then xmlrpclib and was not able to figure out. But, changing the assert to line above fix it

Signed-off-by: Ramon Medeiros <ramon.rnm@gmail.com>