### PR TITLE
Fast suite solver and fast dry_run

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,6 @@ setup(name='robotframework-pabot',
             'pabotworker=pabot.workerwrapper:main']},
       license='Apache License, Version 2.0',
       install_requires=[
-            'robotframework',
+            'robotframework==3.1.2',
             'robotremoteserver>=1.1',
             'typing;python_version<"3.5"'])


### PR DESCRIPTION
Solve suite names faster using `robot.running.TestSuiteBuilder` instead of running "dryrun" process for "suite_names.xml" file.
Run "dryrun" suites faster by chunking all available suites for each process. (f.e. 1000 tests on 4 process will run 250 dryrun tests per process)

With this changes dryrun's will run faster than `robot` and prev `pabot` dryrun's.
For example, dry_run for ~3k tests took:
- 25min with these changes
- 60+min without these changes
- 45min using `robot --dryrun`

P.S. `robotframework==3.1.2` was added because `_with_modified_robot` doesn't have compatibility for RF 3.2 and selftests would fail in Travis. You can skip this commit if you have plans adding 3.2 compatibility.