### PR TITLE
add argumentfile support

### DIFF
--- a/tests/suitearg.txt
+++ b/tests/suitearg.txt
@@ -1,0 +1,2 @@
+--suite suite_one
+--suite suite_second

--- a/tests/test_pabot.py
+++ b/tests/test_pabot.py
@@ -933,11 +933,15 @@ class PabotTests(unittest.TestCase):
                                                 pabot._get_suite_root_name(
                                                     [suite_names]))
             with open(os.path.join(dtemp, 'pabot_results', '0', 'argumentfile.txt'), 'r') as f:
-                self.assertEqual(f.readline().strip(), '--suite Fixtures.Suite One')
+                f_content = f.read()
+                self.assertIn('--suite Fixtures.Suite One', f_content)
+                self.assertNotIn('--suite Fixtures.Suite Second', f_content)
             with open(os.path.join(dtemp, 'pabot_results', '0', 'robot_stdout.out'), 'r') as f:
                 self.assertIn('4 tests total, 2 passed, 2 failed', f.read())
             with open(os.path.join(dtemp, 'pabot_results', '1', 'argumentfile.txt'), 'r') as f:
-                self.assertEqual(f.readline().strip(), '--suite Fixtures.Suite Second')
+                f_content = f.read()
+                self.assertIn('--suite Fixtures.Suite Second', f_content)
+                self.assertNotIn('--suite Fixtures.Suite One', f_content)
             with open(os.path.join(dtemp, 'pabot_results', '1', 'robot_stdout.out'), 'r') as f:
                 self.assertIn('5 tests total, 3 passed, 2 failed', f.read())
             self.assertEqual(4, result_code)


### PR DESCRIPTION
#292 fixes

@mkorpela what do you think of this fix? If a --argumentfile is present, all options are written to the process own file argument.

it is still not possible to use --argumentfile and --argumentfile[N] together, and having --suite, --include, or --test along with argumentfile[N] still leads to problems. But judging by the concept of argumentfile[N], there is no provision for such options. Maybe you should prohibit this with an exception?