### PR TITLE
Add LICENSE.txt to source distributions with MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE.txt

--- a/setup.py
+++ b/setup.py
@@ -32,4 +32,5 @@ setup(name='robotframework-pabot',
       license='Apache License, Version 2.0',
       install_requires=[
             'robotframework',
-            'typing;python_version<"3.5"'])
+            'typing;python_version<"3.5"'],
+      include_package_data=True)


### PR DESCRIPTION
Thanks for pabot!

I'm looking at re-packaging pabot for conda-forge, and noticed the license isn't included in the `sdist`. I'll be able to get it going without (by downloading the license at the right tag, thanks for that!) but it would be ideal if it was included in the future.

This PR adds:
- a `MANIFEST.in`
- the `setup.py` flag to enable picking up the data

Thanks again!