### PR TITLE
Do not apply prerunmodifiers again

### DIFF
--- a/pabot/pabot.py
+++ b/pabot/pabot.py
@@ -1741,6 +1741,8 @@ def main(args=None):
             _initialize_queue_index()
         outs_dir = _output_dir(options)
         suite_names = solve_suite_names(outs_dir, datasources, options, pabot_args)
+        if opts_for_run.get("prerunmodifier"):
+            opts_for_run["prerunmodifier"] = []
         if pabot_args["verbose"]:
             _write("Suite names resolved in %s seconds" % str(time.time() - start_time))
         ordering = pabot_args.get("ordering")


### PR DESCRIPTION
We are applying prerunmodifiers while generating suite names in `generate_suite_names_with_builder`
https://github.com/mkorpela/pabot/blob/a33114dea48ee2da591642531bc733a1ebf46970/pabot/pabot.py#L1073-L1077

After this every parallel process are applying prerunmodifiers again because they are still in robot's options.
It leads to unnessesary checks especialy if prerunmodifier uses external APIs or has complex algorythm.