### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,9 @@ setup(
     author=name,
     author_email=address,
     url="https://pabot.org",
+    project_urls={
+        "Source": "https://github.com/mkorpela/pabot",
+    },
     download_url="https://pypi.python.org/pypi/robotframework-pabot",
     packages=find_packages(),
     classifiers=[


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)