### PR TITLE
Force coloring of the stdout when integrated in CI tools (eg: Gitlab)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ Example usages:
      pabot --pabotlib --pabotlibhost 192.168.1.111 --pabotlibport 8272 --processes 10 tests
      pabot --artifacts png,mp4,txt --artifactsinsubfolders directory_to_tests
 
+### Environment variable
+
+The following environment variable is used by Pabot :
+
+  * PABOT_FORCE_COLOR : if set to 'true' or '1', it will force colors in the stdout messages (usefull when integrated in a CI tool such as Gitlab).
+
 ### PabotLib
 
 pabot.PabotLib provides keywords that will help communication and data sharing between the executor processes.

--- a/pabot/pabot.py
+++ b/pabot/pabot.py
@@ -1495,7 +1495,13 @@ def _wrap_with(color, message):
 
 
 def _is_output_coloring_supported():
-    return sys.stdout.isatty() and os.name in Color.SUPPORTED_OSES
+    return (sys.stdout.isatty() and os.name in Color.SUPPORTED_OSES) \
+           or _is_output_coloring_forced()
+
+
+def _is_output_coloring_forced():
+    pabot_force_color_env = os.environ.get('PABOT_FORCE_COLOR')
+    return pabot_force_color_env.lower() == 'true' or pabot_force_color_env == '1'
 
 
 def _start_message_writer():


### PR DESCRIPTION
When Pabot is launched by a Gitlab runner, the output is redirected and printed in the Gitlab job console.
The current implementation of coloring in Pabot checks if Pabot runs in a terminal, and prevents the output from being colored if not (https://github.com/mkorpela/pabot/pull/31)

However, Gitlab supports [coloring of the jobs log](https://docs.gitlab.com/ee/ci/yaml/script.html#add-color-codes-to-script-output), and it would be interesting to be able to force the colored output: for instance, you can do it in Ansible using the environment variable ANSIBLE_FORCE_COLOR.

These is a pull request implementing this mechanism : if the environment variable PABOT_FORCE_COLOR is set to 'true' or '1', we force the output coloring, regardless of the os or redirection. I tested in our Gitlab CI and it works correctly.

Thanks in advance for your review.