### PR TITLE
Dependency management.

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,12 +203,31 @@ After this come the suite names.
 
 With ```--ordering FILENAME``` you can have a list that controls order also. The syntax is same as .pabotsuitenames file syntax but does not contain 4 hash rows that are present in .pabotsuitenames. 
 
-There are four possibilities to influence the execution:
+There are five possibilities to influence the execution:
 
   * The order of suites can be changed.
   * If a directory (or a directory structure) should be executed sequentially, add the directory suite name to a row.
   * You can add a line with text `#WAIT` to force executor to wait until all previous suites have been executed.
   * You can group suites and tests together to same executor process by adding line `{` before the group and `}`after.
+  * You can introduce dependencies using the word `#DEPENDS` after a test declaration. Please take care that in case of circular dependencies an exception will be thrown. An example could be.
+
+```
+--test robotTest.1 Scalar.Test With Environment Variables #DEPENDS robotTest.1 Scalar.Test with BuiltIn Variables of Robot Framework
+--test robotTest.1 Scalar.Test with BuiltIn Variables of Robot Framework
+--test robotTest.2 Lists.Test with Keywords and a list
+#WAIT
+--test robotTest.2 Lists.Test with a Keyword that accepts multiple arguments
+--test robotTest.2 Lists.Test with some Collections keywords
+--test robotTest.2 Lists.Test to access list entries
+--test robotTest.3 Dictionary.Test that accesses Dictionaries
+--test robotTest.3 Dictionary.Dictionaries for named arguments #DEPENDS robotTest.3 Dictionary.Test that accesses Dictionaries
+--test robotTest.1 Scalar.Test Case With Variables #DEPENDS robotTest.3 Dictionary.Test that accesses Dictionaries
+--test robotTest.1 Scalar.Test with Numbers #DEPENDS robotTest.1 Scalar.Test With Arguments and Return Values
+--test robotTest.1 Scalar.Test Case with Return Values #DEPENDS robotTest.1 Scalar.Test with Numbers
+--test robotTest.1 Scalar.Test With Arguments and Return Values
+--test robotTest.3 Dictionary.Test with Dictionaries as Arguments
+--test robotTest.3 Dictionary.Test with FOR loops and Dictionaries #DEPENDS robotTest.1 Scalar.Test Case with Return Values
+```
 
 ### Global variables
 

--- a/pabot/arguments.py
+++ b/pabot/arguments.py
@@ -7,7 +7,7 @@ from robot.errors import DataError
 from robot.run import USAGE
 from robot.utils import ArgumentParser
 
-from .execution_items import (
+from execution_items import (
     DynamicTestItem,
     ExecutionItem,
     GroupEndItem,

--- a/pabot/clientwrapper.py
+++ b/pabot/clientwrapper.py
@@ -1,7 +1,7 @@
 import sys
 
 try:
-    from .py3.client import make_order
+    from py3.client import make_order
 except SyntaxError:
 
     def make_order(*args):

--- a/pabot/execution_items.py
+++ b/pabot/execution_items.py
@@ -97,14 +97,34 @@ class GroupItem(ExecutionItem):
             options[item.type].append(opts[item.type])
 
 
-class SuiteItem(ExecutionItem):
+class RunnableItem(ExecutionItem):
+    pass
+
+    depends = None  # type: str
+    depends_keyword = "#DEPENDS"
+
+    def set_name_and_depends(self, name):
+        line_name = name.encode("utf-8") if PY2 and is_unicode(name) else name
+        depends_begin_index = line_name.find(self.depends_keyword)
+        self.name = line_name if depends_begin_index == -1 else line_name[0:depends_begin_index].strip()
+        self.depends = line_name[depends_begin_index+len(self.depends_keyword):].strip() if depends_begin_index != -1 \
+            else None
+
+    def line(self):
+        # type: () -> str
+        line_without_depends = "--" + self.type + " " + self.name
+        return line_without_depends + " " + self.depends_keyword + " " + self.depends if self.depends \
+            else line_without_depends
+
+
+class SuiteItem(RunnableItem):
 
     type = "suite"
 
     def __init__(self, name, tests=None, suites=None, dynamictests=None):
         # type: (str, Optional[List[str]], Optional[List[str]], Optional[List[str]]) -> None
         assert (PY2 and isinstance(name, basestring)) or isinstance(name, str)
-        self.name = name.encode("utf-8") if PY2 and is_unicode(name) else name
+        self.set_name_and_depends(name)
         testslist = [
             TestItem(t) for t in tests or []
         ]  # type: List[Union[TestItem, DynamicTestItem]]
@@ -113,10 +133,6 @@ class SuiteItem(ExecutionItem):
         ]  # type: List[Union[TestItem, DynamicTestItem]]
         self.tests = testslist + dynamictestslist
         self.suites = [SuiteItem(s) for s in suites or []]
-
-    def line(self):
-        # type: () -> str
-        return "--suite " + self.name
 
     def difference(self, from_items):
         # type: (List[ExecutionItem]) -> List[ExecutionItem]
@@ -137,17 +153,13 @@ class SuiteItem(ExecutionItem):
         return []
 
 
-class TestItem(ExecutionItem):
+class TestItem(RunnableItem):
 
     type = "test"
 
     def __init__(self, name):
         # type: (str) -> None
-        self.name = name.encode("utf-8") if PY2 and is_unicode(name) else name
-
-    def line(self):
-        # type: () -> str
-        return "--test " + self.name
+        self.set_name_and_depends(name)
 
     if ROBOT_VERSION >= "3.1":
 

--- a/pabot/pabot.py
+++ b/pabot/pabot.py
@@ -107,10 +107,10 @@ from robot.run import USAGE
 from robot.running import TestSuiteBuilder
 from robot.utils import PY2, SYSTEM_ENCODING, ArgumentParser, is_unicode
 
-from . import pabotlib
-from .arguments import parse_args, parse_execution_item_line
-from .clientwrapper import make_order
-from .execution_items import (
+import pabotlib
+from arguments import parse_args, parse_execution_item_line
+from clientwrapper import make_order
+from execution_items import (
     DynamicSuiteItem,
     ExecutionItem,
     GroupEndItem,
@@ -120,8 +120,10 @@ from .execution_items import (
     SuiteItem,
     SuiteItems,
     TestItem,
+    RunnableItem,
+    WaitItem,
 )
-from .result_merger import merge
+from result_merger import merge
 
 try:
     import queue  # type: ignore
@@ -786,7 +788,7 @@ else:
         return open(".pabotsuitenames", mode, encoding="utf-8")
 
 
-def shard_suites(suite_names, pabot_args):
+def solve_shard_suites(suite_names, pabot_args):
     if pabot_args.get("shardcount", 1) <= 1:
         return suite_names
     if "shardindex" not in pabot_args:
@@ -895,24 +897,32 @@ def _regenerate(
         and "suitesfrom" in pabot_args
         and os.path.isfile(pabot_args["suitesfrom"])
     ):
-        suites = _suites_from_outputxml(pabot_args["suitesfrom"])
-        if file_h is None or file_h.dirs != h.dirs:
-            all_suites = generate_suite_names_with_builder(
-                outs_dir, datasources, options
-            )
-        else:
-            all_suites = [suite for suite in lines if suite]
-        suites = _preserve_order(all_suites, suites)
+        suites = _suites_from_file(file_h, h, pabot_args, outs_dir, datasources, options, lines)
     else:
-        suites = _levelsplit(
-            generate_suite_names_with_builder(outs_dir, datasources, options),
-            pabot_args,
-        )
-        suites = _preserve_order(suites, [suite for suite in lines if suite])
+        suites = _suites_from_wrong_or_empty_file(pabot_args, outs_dir, datasources, options, lines)
     if suites:
         store_suite_names(h, suites)
     assert all(isinstance(s, ExecutionItem) for s in suites)
     return suites
+
+
+def _suites_from_file(file_h, h, pabot_args, outs_dir, datasources, options, lines):
+    suites = _suites_from_outputxml(pabot_args["suitesfrom"])
+    if file_h is None or file_h.dirs != h.dirs:
+        all_suites = generate_suite_names_with_builder(
+            outs_dir, datasources, options
+        )
+    else:
+        all_suites = [suite for suite in lines if suite]
+    return _preserve_order(all_suites, suites)
+
+
+def _suites_from_wrong_or_empty_file(pabot_args, outs_dir, datasources, options, lines):
+    suites = _levelsplit(
+        generate_suite_names_with_builder(outs_dir, datasources, options),
+        pabot_args,
+    )
+    return _preserve_order(suites, [suite for suite in lines if suite])
 
 
 def _contains_suite_and_test(suites):
@@ -923,6 +933,8 @@ def _contains_suite_and_test(suites):
 
 def _preserve_order(new_items, old_items):
     assert all(isinstance(s, ExecutionItem) for s in new_items)
+    if not old_items:
+        return new_items
     assert all(isinstance(s, ExecutionItem) for s in old_items)
     old_contains_tests = any(isinstance(t, TestItem) for t in old_items)
     old_contains_suites = any(isinstance(s, SuiteItem) for s in old_items)
@@ -1621,7 +1633,7 @@ class QueueItem(object):
 
 
 def _create_execution_items(
-    suite_names, datasources, outs_dir, options, opts_for_run, pabot_args
+    suite_groups, datasources, outs_dir, options, opts_for_run, pabot_args
 ):
     is_dry_run = (
         options.get("dryrun")
@@ -1630,11 +1642,11 @@ def _create_execution_items(
     )
     if is_dry_run:
         all_items = _create_execution_items_for_dry_run(
-            suite_names, datasources, outs_dir, opts_for_run, pabot_args
+            suite_groups, datasources, outs_dir, opts_for_run, pabot_args
         )
     else:
         all_items = _create_execution_items_for_run(
-            suite_names, datasources, outs_dir, options, opts_for_run, pabot_args
+            suite_groups, datasources, outs_dir, options, opts_for_run, pabot_args
         )
     _construct_index_and_completed_index(all_items)
     _construct_last_levels(all_items)
@@ -1651,12 +1663,12 @@ def _construct_index_and_completed_index(all_items):
 
 
 def _create_execution_items_for_run(
-    suite_names, datasources, outs_dir, options, opts_for_run, pabot_args
+    suite_groups, datasources, outs_dir, options, opts_for_run, pabot_args
 ):
     global _NUMBER_OF_ITEMS_TO_BE_EXECUTED
     all_items = []  # type: List[List[QueueItem]]
     _NUMBER_OF_ITEMS_TO_BE_EXECUTED = 0
-    for suite_group in suite_names:
+    for suite_group in suite_groups:
         # TODO: Fix this better
         if (
             options.get("randomize") in ["all", "suites"]
@@ -1690,13 +1702,13 @@ def _create_items(datasources, opts_for_run, outs_dir, pabot_args, suite_group):
 
 
 def _create_execution_items_for_dry_run(
-    suite_names, datasources, outs_dir, opts_for_run, pabot_args
+    suite_groups, datasources, outs_dir, opts_for_run, pabot_args
 ):
     global _NUMBER_OF_ITEMS_TO_BE_EXECUTED
     all_items = []  # type: List[List[QueueItem]]
     _NUMBER_OF_ITEMS_TO_BE_EXECUTED = 0
     processes_count = pabot_args["processes"]
-    for suite_group in suite_names:
+    for suite_group in suite_groups:
         items = _create_items(
             datasources, opts_for_run, outs_dir, pabot_args, suite_group
         )
@@ -1854,25 +1866,18 @@ def main(args=None):
         if _pabotlib_in_use():
             _initialize_queue_index()
         outs_dir = _output_dir(options)
-        suite_names = solve_suite_names(outs_dir, datasources, options, pabot_args)
-        suite_names = shard_suites(suite_names, pabot_args)
+        suite_groups = _group_suites(outs_dir, datasources, options, pabot_args)
         if pabot_args["verbose"]:
             _write("Suite names resolved in %s seconds" % str(time.time() - start_time))
-        ordering = pabot_args.get("ordering")
-        if ordering:
-            suite_names = _preserve_order(suite_names, ordering)
-        if pabot_args["chunk"]:
-            suite_names = _chunked_suite_names(suite_names, pabot_args["processes"])
-        else:
-            suite_names = _group_by_wait(_group_by_groups(suite_names))
-        if not suite_names or suite_names == [[]]:
+        if not suite_groups or suite_groups == [[]]:
             _write("No tests to execute")
             if not options.get("runemptysuite", False):
                 sys.exit(252)
         execution_items = _create_execution_items(
-            suite_names, datasources, outs_dir, options, opts_for_run, pabot_args
+            suite_groups, datasources, outs_dir, options, opts_for_run, pabot_args
         )
         while execution_items:
+            print(execution_items[0])
             items = execution_items.pop(0)
             _parallel_execute(
                 items,
@@ -1887,7 +1892,7 @@ def main(args=None):
             pabot_args,
             options,
             start_time_string,
-            _get_suite_root_name(suite_names),
+            _get_suite_root_name(suite_groups),
         )
         sys.exit(result_code if not _ABNORMAL_EXIT_HAPPENED else 252)
     except Information as i:
@@ -1910,6 +1915,17 @@ def main(args=None):
         _stop_message_writer()
 
 
+def _group_suites(outs_dir, datasources, options, pabot_args):
+    suite_names = solve_suite_names(outs_dir, datasources, options, pabot_args)
+    _verify_depends(suite_names)
+    shard_suites = solve_shard_suites(suite_names, pabot_args)
+    ordered_suites = _preserve_order(shard_suites, pabot_args.get("ordering"))
+    grouped_suites = _chunked_suite_names(ordered_suites, pabot_args["processes"]) if pabot_args["chunk"] \
+        else _group_by_wait(_group_by_groups(ordered_suites))
+    grouped_by_depend = _all_grouped_suites_by_depend(grouped_suites)
+    return grouped_by_depend
+
+
 def _chunked_suite_names(suite_names, processes):
     q, r = divmod(len(suite_names), processes)
     result = []
@@ -1924,6 +1940,39 @@ def _chunked_suite_names(suite_names, processes):
             grouped.add(item)
         result.append(grouped)
     return [result]
+
+
+def _verify_depends(suite_names):
+    runnable_suites = list(filter(lambda suite: isinstance(suite, RunnableItem), suite_names))
+    suites_with_depends = list(filter(lambda suite: suite.depends, runnable_suites))
+    suites_with_found_dependencies = list(filter(lambda suite: any(runnable_suite.name == suite.depends for runnable_suite in runnable_suites), suites_with_depends))
+    if suites_with_depends != suites_with_found_dependencies:
+        raise Exception("There are unmet dependencies using #DEPENDS")
+    suites_with_circular_dependencies = list(filter(lambda suite: suite.depends == suite.name, suites_with_depends))
+    if suites_with_circular_dependencies:
+        raise Exception("There are suites with circular dependencies using #DEPENDS")
+
+
+def _group_by_depend(suite_names):
+    runnable_suites = list(filter(lambda suite: isinstance(suite, RunnableItem), suite_names))
+    independent_tests = list(filter(lambda suite: not suite.depends, runnable_suites))
+    dependency_tree = [independent_tests]
+    while True:
+        dependent_tests = list(filter(lambda suite: suite.depends, runnable_suites))
+        dependent_on_last_stage = list(filter(lambda suite: any(test_in_tier_before.name == suite.depends for test_in_tier_before in dependency_tree[-1]), dependent_tests))
+        if not dependent_on_last_stage: break
+        dependency_tree += [dependent_on_last_stage]
+    flattened_dependency_tree = sum(dependency_tree, [])
+    if len(flattened_dependency_tree) != len(runnable_suites):
+        raise Exception("There are circular or unmet dependencies using #DEPENDS")
+    return dependency_tree
+
+
+def _all_grouped_suites_by_depend(grouped_suites):
+    grouped_by_depend = []
+    for group_suite in grouped_suites:
+        grouped_by_depend += _group_by_depend(group_suite)
+    return grouped_by_depend
 
 
 if __name__ == "__main__":

--- a/pabot/pabotlib.py
+++ b/pabot/pabotlib.py
@@ -33,7 +33,7 @@ from robot.libraries.BuiltIn import BuiltIn
 from robot.libraries.Remote import Remote
 from robot.running import TestLibrary
 
-from .robotremoteserver import RobotRemoteServer
+from robotremoteserver import RobotRemoteServer
 
 PABOT_LAST_LEVEL = "PABOTLASTLEVEL"
 PABOT_QUEUE_INDEX = "PABOTQUEUEINDEX"


### PR DESCRIPTION
- A new keyword '#DEPENDS' is introduced in the .pabotsuitenames file, enabling declaring tests independent of each other.
- Enable comments in the suite and test items.
- Extract logic to grouping the suites in an extra method.

Address issue #462 