### PR TITLE
Fix testlevelsplit output testcase order.

### DIFF
--- a/pabot/pabot.py
+++ b/pabot/pabot.py
@@ -94,6 +94,7 @@ from contextlib import closing
 from glob import glob
 from io import BytesIO, StringIO
 from multiprocessing.pool import ThreadPool
+from natsort import natsorted
 
 from robot import __version__ as ROBOT_VERSION
 from robot import rebot
@@ -1445,7 +1446,7 @@ def _merge_one_run(
     output_path = os.path.abspath(
         os.path.join(options.get("outputdir", "."), outputfile)
     )
-    files = sorted(glob(os.path.join(_glob_escape(outs_dir), "**/*.xml")))
+    files = natsorted(glob(os.path.join(_glob_escape(outs_dir), "**/*.xml")))
     if not files:
         _write('WARN: No output files in "%s"' % outs_dir, Color.YELLOW)
         return ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ isort==5.9.3
 mccabe==0.6.1
 mypy==0.901
 mypy-extensions==0.4.3
+natsort==8.2.0
 pre-commit==2.14.1
 pytest==6.2.5
 robotframework==4.0.3

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     ],
     entry_points={"console_scripts": ["pabot=pabot.pabot:main"]},
     license="Apache License, Version 2.0",
-    install_requires=["robotframework>=3.2", "robotframework-stacktrace>=0.4.1"],
+    install_requires=["robotframework>=3.2", "robotframework-stacktrace>=0.4.1", "natsort>=8.2.0"],
     python_requires=">=3.6",
     include_package_data=True,
 )

--- a/tests/test_testlevelsplit_output_task_order.py
+++ b/tests/test_testlevelsplit_output_task_order.py
@@ -1,0 +1,90 @@
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+
+from robot.api import ExecutionResult
+
+
+class PabotTestlevelsplitOutputTaskOrderTest(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def _run_tests_with(self, testfile):
+        robot_file = open("{}/test.robot".format(self.tmpdir), "w")
+        robot_file.write(textwrap.dedent(testfile))
+        robot_file.close()
+        process = subprocess.Popen(
+            [
+                sys.executable,
+                "-m" "pabot.pabot",
+                "--testlevelsplit",
+                "{}/test.robot".format(self.tmpdir),
+            ],
+            cwd=self.tmpdir,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        process.wait()
+
+    def test_testlevelsplit_output_task_order(self):
+        self._run_tests_with(
+            """
+                *** Test Cases ***
+                Test 1
+                    Log    Executing test
+
+                Test 2
+                    Log    Executing test
+
+                Test 3
+                    Log    Executing test
+
+                Test 4
+                    Log    Executing test
+
+                Test 5
+                    Log    Executing test
+
+                Test 6
+                    Log    Executing test
+
+                Test 7
+                    Log    Executing test
+
+                Test 8
+                    Log    Executing test
+
+                Test 9
+                    Log    Executing test
+
+                Test 10
+                    Log    Executing test
+
+                Test 11
+                    Log    Executing test
+            """
+        )
+        result = ExecutionResult("{}/output.xml".format(self.tmpdir))
+        test_names = [test.name for test in result.suite.tests]
+        self.assertEqual(
+            [
+                "Test 1",
+                "Test 2",
+                "Test 3",
+                "Test 4",
+                "Test 5",
+                "Test 6",
+                "Test 7",
+                "Test 8",
+                "Test 9",
+                "Test 10",
+                "Test 11",
+            ],
+            test_names
+        )


### PR DESCRIPTION
FIxes ordering of testcases in the output files when `--testlevelsplit` option is used by sorting output files with `natsort` before merging them to preserve the correct order of the containing directories.

Issue #493 