### PR TITLE
use copy2 to preserve artifact timestamps, etc.

### DIFF
--- a/pabot/pabot.py
+++ b/pabot/pabot.py
@@ -1345,7 +1345,7 @@ def _copy_output_artifacts(options, file_extensions=None, include_subfolders=Fal
                     if not os.path.isdir(dst_folder_path):
                         os.makedirs(dst_folder_path)
                 dst_file_name = "-".join([prefix, file_name])
-                shutil.copyfile(
+                shutil.copy2(
                     os.path.join(location, file_name),
                     os.path.join(dst_folder_path, dst_file_name),
                 )


### PR DESCRIPTION
Thanks for pabot!

This proposes replacing `shutil.copyfile` with `shutil.copy2` to preserve artifact metadata like times when merged.

No hardship if this is not desired, but seemed easier to just PR than have a big discussion about _not_ wanting it.