### PR TITLE
Added options to parallelize tests by tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ There are several ways you can help in improving this tool:
 
     pabot [--verbose|--testlevelsplit|--command .. --end-command|
            --processes num|--pabotlib|--pabotlibhost host|--pabotlibport port|
-           --processtimeout num|
+           --processtimeout num|--tags tags| --runnonespecifiedtags
            --shard i/n|
            --artifacts extensions|--artifactsinsubfolders|
            --resourcefile file|--argumentfile[num] file|--suitesfrom file] 
@@ -83,6 +83,13 @@ Supports all [Robot Framework command line options](https://robotframework.org/r
   How many parallel executors to use (default max of 2 and cpu count).
   Special option "all" will use as many processes as there are
   executable suites or tests.
+
+--tags   [TAGS SEPARATED BY COMMA]          
+  Divides the processes by tag. 
+  If used with --processes option, will ignore the number of processes and create a process for each tag.
+
+--runnonespecifiedtags          
+  If --tags was used, will create a process to run all tests without the especified tags
 
 --pabotlib          
   Start PabotLib remote server. This enables locking and resource distribution between parallel test executions.
@@ -145,6 +152,7 @@ Example usages:
      pabot --pabotlibhost 192.168.1.123 --pabotlibport 8271 --processes 10 tests
      pabot --pabotlib --pabotlibhost 192.168.1.111 --pabotlibport 8272 --processes 10 tests
      pabot --artifacts png,mp4,txt --artifactsinsubfolders directory_to_tests
+     pabot --tags tag1,tag2,tag3 --runnonespecifiedtags tests 
 
 ### PabotLib
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -40,7 +40,8 @@ OR clone this repository and run:
 ## Параметры командной строки
 
     pabot [--verbose|--testlevelsplit|--command .. --end-command|
-           --processes num|--pabotlib|--pabotlibhost host|--pabotlibport port|
+           --processes num|--tags tags|--runnonespecifiedtags|--pabotlib|
+           --pabotlibhost host|--pabotlibport port|
            --artifacts extensions|--artifactsinsubfolders|
            --resourcefile file|--argumentfile[num] file|--suitesfrom file] 
           [robot options] [path ...]
@@ -64,6 +65,13 @@ OR clone this repository and run:
 
 --processes   [NUMBER OF PROCESSES]          
   Сколько параллельных исполнителей использовать (по умолчанию максимум 2 и количество процессоров).
+
+--tags  [TAGS SEPARATED BY COMMA]  
+   Разделяет процессы по тегам.
+   Если используется с параметром --processes, количество процессов будет игнорироваться, и для каждого тега будет создан процесс.
+
+--runnonespecifiedtags
+   Если был использован параметр --tags, будет создан процесс для запуска всех тестов без указанных тегов.
 
 --pabotlib          
   Запустите PabotLib удаленный сервер. Это позволяет блокировать и распределять ресурсы между параллельными выполнениями теста.
@@ -116,7 +124,7 @@ Example usages:
      pabot --pabotlibhost 192.168.1.123 --pabotlibport 8271 --processes 10 tests
      pabot --pabotlib --pabotlibhost 192.168.1.111 --pabotlibport 8272 --processes 10 tests
      pabot --artifacts png,mp4,txt --artifactsinsubfolders directory_to_tests
-
+     pabot --tags tag1,tag2,tag3 --runnonespecifiedtags tests 
 ### PabotLib
 
 pabot.PabotLib предоставляет ключевые слова, которые помогут коммуникации и обмену данными между процессами исполнителя.

--- a/README_zh.md
+++ b/README_zh.md
@@ -58,6 +58,13 @@
 --processes   [进程数]          
   要使用多少个并行执行程序（默认最大值为2和cpu计数）
 
+--tags [逗号分隔的标签]
+   按标签划分进程。
+   如果与 --processes 选项一起使用，将忽略进程数并为每个标记创建一个进程。
+
+--runnonespecifiedtags
+   如果使用了 --tags，将创建一个进程来运行所有没有指定标签的测试
+   
 --pabotlib          
   启动PabotLib远程服务器。 这样可以在并行测试执行之间进行锁定和资源分配。
 
@@ -96,7 +103,7 @@
      pabot --processes 10 tests
      pabot --pabotlibhost 192.168.1.123 --pabotlibport 8271 --processes 10 tests
      pabot --pabotlib --pabotlibhost 192.168.1.111 --pabotlibport 8272 --processes 10 tests
-
+     pabot --tags tag1,tag2,tag3 --runnonespecifiedtags tests 
 ### PabotLib
 
 pabot.PabotLib提供的关键字有助于执行程序进程之间的通信和数据共享。

--- a/src/pabot/arguments.py
+++ b/src/pabot/arguments.py
@@ -72,6 +72,8 @@ def _parse_pabot_args(args):  # type: (List[str]) -> Tuple[List[str], Dict[str, 
         "pabotlibhost": "127.0.0.1",
         "pabotlibport": 8270,
         "processes": _processes_count(),
+        "tags": None,
+        "runnonespecifiedtags": False,
         "processtimeout": None,
         "artifacts": ["png"],
         "artifactsinsubfolders": False,
@@ -88,6 +90,8 @@ def _parse_pabot_args(args):  # type: (List[str]) -> Tuple[List[str], Dict[str, 
                 "hive",
                 "command",
                 "processes",
+                "tags",
+                "runnonespecifiedtags",
                 "verbose",
                 "resourcefile",
                 "testlevelsplit",
@@ -118,6 +122,14 @@ def _parse_pabot_args(args):  # type: (List[str]) -> Tuple[List[str], Dict[str, 
         if args[0] == "--processes":
             pabot_args["processes"] = int(args[1]) if args[1] != 'all' else None
             args = args[2:]
+            continue
+        if args[0] == "--tags":
+            pabot_args["tags"] = args[1].split(',')
+            args = args[2:]
+            continue
+        if args[0] == "--runnonespecifiedtags":
+            pabot_args["runnonespecifiedtags"] = True
+            args = args[1:]
             continue
         if args[0] == "--verbose":
             pabot_args["verbose"] = True


### PR DESCRIPTION
While attempting to run tests on multiple suites that shared the same user account, I encountered a problem. The tests required three different types of user accounts, but there was only one account of each type available for testing. When I tried to parallelize the tests, different suites began updating the same account, resulting in broken tests.

To fix this issue, I added a new feature that allows the creation of a separate process for each tag. For example, running the command 
"pabot --tags user,admin,manager tests" would result in:
process 1 running the tests with the "user" tag
process 2 running the tests with the "admin" tag
process 3 running the tests with the "manager" tag.

In addition, I also added an option to create a process that runs all the other tests that do not have these tags. This can be done with the command 
"pabot --tags user,admin,manager --runnonespecifiedtags tests". As a result: 
process 1 will run the tests with the "user" tag
process 2 will run the tests with the "admin" tag
process 3 will run the tests with the "manager" tag
process 4 will run all the other tests that were not specified with these tags.
