### PR TITLE
Updates to support Robot 6.1

### DIFF
--- a/src/pabot/pabot.py
+++ b/src/pabot/pabot.py
@@ -1258,6 +1258,7 @@ def _options_for_rebot(options, start_time_string, end_time_string):
         "maxassignlength",
         "maxerrorlines",
         "monitorcolors",
+        "parser",
         "prerunmodifier",
         "quiet",
         "randomize",

--- a/src/pabot/result_merger.py
+++ b/src/pabot/result_merger.py
@@ -56,7 +56,7 @@ class ResultMerger(SuiteVisitor):
         try:
             self._set_prefix(merged.source)
             merged.suite.visit(self)
-            self.root.metadata._add_initial(merged.suite.metadata)
+            self.root.metadata.update(merged.suite.metadata)
             if self.errors != merged.errors:
                 self.errors.add(merged.errors)
         except:

--- a/tests/test_pabot.py
+++ b/tests/test_pabot.py
@@ -1045,6 +1045,7 @@ class PabotTests(unittest.TestCase):
                 "prerunmodifier",
                 "monitorcolors",
                 "language",
+                "parser",
             ]:
                 self.assertFalse(key in options, "%s should not be in options" % key)
             else:


### PR DESCRIPTION
Robot 6.1 introduced a new CLI option `parser` which needs to be added to the list of options not valid for `rebot`. 

In addition Pekka removed the private `_add_initial` from  robot's `NormalizedDict`, he suggests to just leverage `.update()` instead (which also works for older releases).. but maybe you had a reason to use `_add_initial` in the first place? 

Fixes #533 