### PR TITLE
ci: test against different robotframework versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,12 @@ jobs:
     strategy:
       matrix:
         python: [3.8, 3.9, 3.11]
+        robotframework:
+          - "3.2.0"
+          - "4.1.0"
+          - "5.0.0"
+          - "6.0.0"
+          - "6.1.0"
 
     steps:
       - uses: actions/checkout@v4
@@ -20,6 +26,7 @@ jobs:
         run: |
          pip install tox
          pip install -r ./requirements.txt
+         pip install "robotframework~=${{ matrix.robotframework }}"
 
       - name: Run Tox
         # Run tox using the version of Python in `PATH`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
         python: [3.8, 3.9, 3.11]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - name: Install Tox and any other packages


### PR DESCRIPTION
Extend ci matrix job to include testing against multiple versions of robotframework.

This will be helpful to confirm that the library works with all of the versions documented (and makes it easier to catch problems in future versions).