### PR TITLE
fix: exclude deprecated options based on RF version

### DIFF
--- a/src/pabot/arguments.py
+++ b/src/pabot/arguments.py
@@ -28,21 +28,33 @@ def _processes_count():  # type: () -> int
         return 2
 
 
+def _filter_argument_parser_options(**options):
+    # Note: auto_pythonpath is deprecated since RobotFramework 5.0, but only
+    # communicated to users from 6.1
+    if ROBOT_VERSION >= "5.0" and "auto_pythonpath" in options:
+        del options["auto_pythonpath"]
+    return options
+
+
 def parse_args(
     args,
 ):  # type: (List[str]) -> Tuple[Dict[str, object], List[str], Dict[str, object], Dict[str, object]]
     args, pabot_args = _parse_pabot_args(args)
     options, datasources = ArgumentParser(
         USAGE,
-        auto_pythonpath=False,
-        auto_argumentfile=True,
-        env_options="ROBOT_OPTIONS",
+        **_filter_argument_parser_options(
+            auto_pythonpath=False,
+            auto_argumentfile=True,
+            env_options="ROBOT_OPTIONS",
+        ),
     ).parse_args(args)
     options_for_subprocesses, sources_without_argfile = ArgumentParser(
         USAGE,
-        auto_pythonpath=False,
-        auto_argumentfile=False,
-        env_options="ROBOT_OPTIONS",
+        **_filter_argument_parser_options(
+            auto_pythonpath=False,
+            auto_argumentfile=False,
+            env_options="ROBOT_OPTIONS",
+        ),
     ).parse_args(args)
     if len(datasources) != len(sources_without_argfile):
         raise DataError(

--- a/src/pabot/pabot.py
+++ b/src/pabot/pabot.py
@@ -114,7 +114,11 @@ from robot.running import TestSuiteBuilder
 from robot.utils import PY2, SYSTEM_ENCODING, ArgumentParser, is_unicode
 
 from . import pabotlib, __version__ as PABOT_VERSION
-from .arguments import parse_args, parse_execution_item_line
+from .arguments import (
+    parse_args,
+    parse_execution_item_line,
+    _filter_argument_parser_options,
+)
 from .clientwrapper import make_order
 from .execution_items import (
     DynamicSuiteItem,
@@ -638,9 +642,11 @@ def _options_for_executor(
 def _modify_options_for_argfile_use(argfile, options, root_name):
     argfile_opts, _ = ArgumentParser(
         USAGE,
-        auto_pythonpath=False,
-        auto_argumentfile=True,
-        env_options="ROBOT_OPTIONS",
+        **_filter_argument_parser_options(
+            auto_pythonpath=False,
+            auto_argumentfile=True,
+            env_options="ROBOT_OPTIONS",
+        ),
     ).parse_args(["--argumentfile", argfile])
     old_name = options.get("name", root_name)
     if argfile_opts["name"]:

--- a/src/pabot/pabot.py
+++ b/src/pabot/pabot.py
@@ -1148,9 +1148,16 @@ def generate_suite_names_with_builder(outs_dir, datasources, options):
     if "pythonpath" in opts:
         del opts["pythonpath"]
     settings = RobotSettings(opts)
-    builder = TestSuiteBuilder(
-        settings["SuiteNames"], settings.extension, rpa=settings.rpa
-    )
+
+    # Note: first argument (included_suites) is deprecated from RobotFramework 6.1
+    if ROBOT_VERSION < "6.1":
+        builder = TestSuiteBuilder(
+            settings["SuiteNames"], settings.extension, rpa=settings.rpa
+        )
+    else:
+        builder = TestSuiteBuilder(
+            included_extensions=settings.extension, rpa=settings.rpa
+        )
     suite = builder.build(*datasources)
     settings.rpa = builder.rpa
     suite.configure(**settings.suite_config)


### PR DESCRIPTION
Resolving deprecation notices (see https://github.com/mkorpela/pabot/issues/539) when using pabot with robotframework (RF) 6.1.

With RF 6.1 it includes more deprecation notices (even for some features that have been deprecated since RF 5.0).

Belows shows example of the deprecation notices as printed on the console prior to this PR.

### ArgumentParser option 'auto_pythonpath' is deprecated since Robot Framework 5.0

```
tests/test_pabot.py: 56 warnings
  /home/runner/work/pabot/pabot/.tox/py/lib/python3.11/site-packages/robot/utils/argumentparser.py:80: UserWarning: ArgumentParser option 'auto_pythonpath' is deprecated since Robot Framework 5.0.
    warnings.warn("ArgumentParser option 'auto_pythonpath' is deprecated "
```

### UserWarning: 'TestSuiteBuilder' argument 'included_suites' is deprecated and has no effect

```
tests/test_pabotsuitenames_io.py: 1 warning
  /home/runner/work/pabot/pabot/.tox/py/lib/python3.11/site-packages/robot/running/builder/builders.py:112: UserWarning: 'TestSuiteBuilder' argument 'included_suites' is deprecated and has no effect. Use the new 'included_files' argument or filter the created suite instead.
    warnings.warn("'TestSuiteBuilder' argument 'included_suites' is deprecated "
```

**Notes**
* https://github.com/mkorpela/pabot/pull/562 could be used to verify this PR as it would test pabot against multiple robotframework versions to verify the functionality across different versions.