### PR TITLE
Fixed groups in ordering file when using --suite command line argument. See: #581

### DIFF
--- a/src/pabot/execution_items.py
+++ b/src/pabot/execution_items.py
@@ -89,9 +89,8 @@ class GroupItem(ExecutionItem):
         self._items.append(item)
 
     def modify_options_for_executor(self, options):
+        options[self._element_type] = []
         for item in self._items:
-            if item.type not in options:
-                options[item.type] = []
             opts = {}
             item.modify_options_for_executor(opts)
             options[item.type].append(opts[item.type])


### PR DESCRIPTION
Fix for issue #581.

The groups in the ordering file don't work correctly when the command line argument `--suite` was given. All suites that were given with this argument were also added to the groups.