### PR TITLE
use sys.executable to run robot

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ Supports all [Robot Framework command line options](https://robotframework.org/r
 --chunk
   Optionally chunk tests to PROCESSES number of robot runs. This can save time because all the suites will share the same setups and teardowns.
 
+--sysexecutable
+  Changes how pabot calls robot/rebot from their executable wrappers into `python -m`  calls using the currently used python interpreter.
+
 Example usages:
 
      pabot test_directory

--- a/src/pabot/arguments.py
+++ b/src/pabot/arguments.py
@@ -1,5 +1,6 @@
 import multiprocessing
 import re
+import sys
 from typing import Dict, List, Optional, Tuple
 
 from robot import __version__ as ROBOT_VERSION
@@ -90,7 +91,9 @@ def _parse_pabot_args(args):  # type: (List[str]) -> Tuple[List[str], Dict[str, 
         "shardindex": 0,
         "shardcount": 1,
         "chunk": False,
+        "sysexecutable": False,
     }
+
     argumentfiles = []
     while args and (
         args[0]
@@ -114,6 +117,7 @@ def _parse_pabot_args(args):  # type: (List[str]) -> Tuple[List[str], Dict[str, 
                 "help",
                 "shard",
                 "chunk",
+                "sysexecutable",
             ]
         ]
         or ARGSMATCHER.match(args[0])
@@ -182,6 +186,11 @@ def _parse_pabot_args(args):  # type: (List[str]) -> Tuple[List[str], Dict[str, 
         if args[0] == "--shard":
             pabot_args["shardindex"], pabot_args["shardcount"] = _parse_shard(args[1])
             args = args[2:]
+            continue
+        if args[0] == "--sysexecutable":
+            pabot_args["command"] = [sys.executable, "-m", "robot"]
+            pabot_args["sysexecutable"] = True
+            args = args[1:]
             continue
         match = ARGSMATCHER.match(args[0])
         if match:

--- a/tests/test_pabot.py
+++ b/tests/test_pabot.py
@@ -6,6 +6,7 @@ import os
 import tempfile
 import shutil
 import random
+import sys
 
 import pabot.execution_items as execution_items
 from pabot import pabot, arguments
@@ -115,6 +116,29 @@ class PabotTests(unittest.TestCase):
         self.assertEqual(options["outputdir"], "myoutputdir")
         self.assertFalse("outputdir" in options_for_subprocesses)
         self.assertTrue(pabot_args["testlevelsplit"])
+        self.assertEqual(datasources, ["suite"])
+
+
+    def test_sys_executable(self):
+        (
+            options,
+            datasources,
+            pabot_args,
+            options_for_subprocesses,
+        ) = arguments.parse_args(
+            [
+                "--verbose",
+                "--sysexecutable",
+                "--removekeywords",
+                "WUKS",
+                "suite"
+            ]
+        )
+        self.assertEqual(pabot_args["command"], [sys.executable, "-m", "robot"])
+        # NOTE: calling rebot is quite deep on the call chain and command is
+        # constructed just before the call so that is not covered. But verified
+        # it via verbose logging when running manually.
+        self.assertEqual(pabot_args["verbose"], True)
         self.assertEqual(datasources, ["suite"])
 
     def test_start_and_stop_remote_library(self):


### PR DESCRIPTION
Fixes #578

Rationale for this change:
  * one could use start-command / end-command but optional rebot call would still be executed via executable
  * automatic RobotStackTrace would not be added if start-command / end-command was used.

Optional --sysexecutable could be removed and functionality of current change be made a sole calling mechanism since existing code is already importing robot to determine version. This sort of makes assumption that pabot and robot are installed in under same python interpreter and usage of executable wrappers is purely optional ?