### PR TITLE
Fix error when running non-English robot case files

### DIFF
--- a/src/pabot/pabot.py
+++ b/src/pabot/pabot.py
@@ -1152,13 +1152,17 @@ def generate_suite_names_with_builder(outs_dir, datasources, options):
     settings = RobotSettings(opts)
 
     # Note: first argument (included_suites) is deprecated from RobotFramework 6.1
-    if ROBOT_VERSION < "6.1":
+    if ROBOT_VERSION < "6.0":
         builder = TestSuiteBuilder(
             settings["SuiteNames"], settings.extension, rpa=settings.rpa
         )
+    elif ROBOT_VERSION < "6.1":
+        builder = TestSuiteBuilder(
+            settings["SuiteNames"], settings.extension, rpa=settings.rpa, lang=opts["language"]
+        )
     else:
         builder = TestSuiteBuilder(
-            included_extensions=settings.extension, rpa=settings.rpa
+            included_extensions=settings.extension, rpa=settings.rpa, lang=opts["language"]
         )
     suite = builder.build(*datasources)
     settings.rpa = builder.rpa

--- a/src/pabot/pabot.py
+++ b/src/pabot/pabot.py
@@ -1154,7 +1154,7 @@ def generate_suite_names_with_builder(outs_dir, datasources, options):
     # Note: first argument (included_suites) is deprecated from RobotFramework 6.1
     if ROBOT_VERSION >= "6.1":
         builder = TestSuiteBuilder(
-            included_extensions=settings.extension, rpa=settings.rpa, lang=opts["language"]
+            included_extensions=settings.extension, rpa=settings.rpa, lang=opts.get("language")
         )
     else:
         builder = TestSuiteBuilder(

--- a/src/pabot/pabot.py
+++ b/src/pabot/pabot.py
@@ -1152,18 +1152,15 @@ def generate_suite_names_with_builder(outs_dir, datasources, options):
     settings = RobotSettings(opts)
 
     # Note: first argument (included_suites) is deprecated from RobotFramework 6.1
-    if ROBOT_VERSION < "6.0":
-        builder = TestSuiteBuilder(
-            settings["SuiteNames"], settings.extension, rpa=settings.rpa
-        )
-    elif ROBOT_VERSION < "6.1":
-        builder = TestSuiteBuilder(
-            settings["SuiteNames"], settings.extension, rpa=settings.rpa, lang=opts["language"]
-        )
-    else:
+    if ROBOT_VERSION >= "6.1":
         builder = TestSuiteBuilder(
             included_extensions=settings.extension, rpa=settings.rpa, lang=opts["language"]
         )
+    else:
+        builder = TestSuiteBuilder(
+            settings["SuiteNames"], settings.extension, rpa=settings.rpa
+        ) 
+
     suite = builder.build(*datasources)
     settings.rpa = builder.rpa
     suite.configure(**settings.suite_config)


### PR DESCRIPTION
pabot use TestSuiteBuilder to parse cases before executing. For cases uses other languages, we need to pass language to TestSuiteBuilder so it can handle properly.