### PR TITLE
Fix incorrect logic to allocate processes with --dryrun option

### DIFF
--- a/src/pabot/pabot.py
+++ b/src/pabot/pabot.py
@@ -1772,7 +1772,7 @@ def _create_execution_items_for_dry_run(
         chunk_size = (
             round(len(items) / processes_count)
             if len(items) > processes_count
-            else len(items)
+            else 1
         )
         chunked_items = list(_chunk_items(items, chunk_size))
         _NUMBER_OF_ITEMS_TO_BE_EXECUTED += len(chunked_items)


### PR DESCRIPTION
When the processes number is greater than items, the chunk_size should be one, that is one time is assigned to one process.
Fixes https://github.com/mkorpela/pabot/issues/590