### PR TITLE
publish wheels

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,5 +1,5 @@
 cd ..
 git clone git@github.com:mkorpela/pabot.git pabotrelease
 cd pabotrelease
-python setup.py sdist
+python -m build
 twine upload -r robotframework-pabot dist/*.*


### PR DESCRIPTION
- direct invocation of `setup.py` [is deprecated](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/)
- publish wheels, so that consumers do not have to build the wheel themselves at every install