### PR TITLE
fix the incorrect elapsed time issue

### DIFF
--- a/src/pabot/result_merger.py
+++ b/src/pabot/result_merger.py
@@ -150,6 +150,8 @@ class ResultMerger(SuiteVisitor):
 
     def merge_time(self, suite):
         cur = self.current
+        if ROBOT_VERSION >= "7.0":
+            cur.elapsed_time = None
         cur.endtime = max([cur.endtime, suite.endtime])
         cur.starttime = min([cur.starttime, suite.starttime])
 

--- a/tests/outputs/output_with_latest_robot/first.xml
+++ b/tests/outputs/output_with_latest_robot/first.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<robot generator="Robot 7.0.1 (Python 3.11.1 on darwin)" generated="2024-12-06T09:41:12.425254" rpa="false" schemaversion="5">
+<suite id="s1" name="Tmp" source="/Users/mkorpela/workspace/pabot/tmp">
+<suite id="s1-s1" name="Tests" source="/Users/mkorpela/workspace/pabot/tmp/tests.robot">
+<test id="s1-s1-t1" name="First" line="4">
+<kw name="Log" owner="BuiltIn">
+<msg time="2024-12-06T09:41:12.583145" level="INFO">this is first</msg>
+<arg>this is first</arg>
+<doc>Logs the given message with the given level.</doc>
+<status status="PASS" start="2024-12-06T09:41:12.582148" elapsed="0.000997"/>
+</kw>
+<kw name="Sleep" owner="BuiltIn">
+<msg time="2024-12-06T09:41:13.599800" level="INFO">Slept 1 second.</msg>
+<arg>1s</arg>
+<doc>Pauses the test executed for the given time.</doc>
+<status status="PASS" start="2024-12-06T09:41:12.584151" elapsed="1.016646"/>
+</kw>
+<kw name="Log" owner="BuiltIn">
+<msg time="2024-12-06T09:41:13.604820" level="INFO">yeah</msg>
+<arg>yeah</arg>
+<doc>Logs the given message with the given level.</doc>
+<status status="PASS" start="2024-12-06T09:41:13.603813" elapsed="0.002005"/>
+</kw>
+<status status="PASS" start="2024-12-06T09:41:12.578940" elapsed="1.026878"/>
+</test>
+<status status="PASS" start="2024-12-06T09:41:12.571947" elapsed="1.041865"/>
+</suite>
+<status status="PASS" start="2024-12-06T09:41:12.482939" elapsed="1.137409"/>
+</suite>
+<statistics>
+<total>
+<stat pass="1" fail="0" skip="0">All Tests</stat>
+</total>
+<tag>
+</tag>
+<suite>
+<stat pass="1" fail="0" skip="0" id="s1" name="Tmp">Tmp</stat>
+<stat pass="1" fail="0" skip="0" id="s1-s1" name="Tests">Tmp.Tests</stat>
+</suite>
+</statistics>
+<errors>
+</errors>
+</robot>

--- a/tests/outputs/output_with_latest_robot/second.xml
+++ b/tests/outputs/output_with_latest_robot/second.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<robot generator="Robot 7.0.1 (Python 3.11.1 on darwin)" generated="2024-12-06T09:41:12.597260" rpa="false" schemaversion="5">
+<suite id="s1" name="Tmp" source="/Users/mkorpela/workspace/pabot/tmp">
+<suite id="s1-s1" name="Tests" source="/Users/mkorpela/workspace/pabot/tmp/tests.robot">
+<test id="s1-s1-t1" name="Second" line="9">
+<kw name="Log" owner="BuiltIn">
+<msg time="2024-12-06T09:41:12.849548" level="INFO">this is second</msg>
+<arg>this is second</arg>
+<doc>Logs the given message with the given level.</doc>
+<status status="PASS" start="2024-12-06T09:41:12.848548" elapsed="0.002000"/>
+</kw>
+<kw name="Sleep" owner="BuiltIn">
+<msg time="2024-12-06T09:41:14.038911" level="INFO">Slept 1 second.</msg>
+<arg>1s</arg>
+<doc>Pauses the test executed for the given time.</doc>
+<status status="PASS" start="2024-12-06T09:41:12.851549" elapsed="1.187362"/>
+</kw>
+<kw name="Log" owner="BuiltIn">
+<msg time="2024-12-06T09:41:14.040913" level="INFO">wohoo</msg>
+<arg>wohoo</arg>
+<doc>Logs the given message with the given level.</doc>
+<status status="PASS" start="2024-12-06T09:41:14.039912" elapsed="0.002001"/>
+</kw>
+<status status="PASS" start="2024-12-06T09:41:12.844549" elapsed="1.197364"/>
+</test>
+<status status="PASS" start="2024-12-06T09:41:12.807856" elapsed="1.238057"/>
+</suite>
+<status status="PASS" start="2024-12-06T09:41:12.649373" elapsed="1.405075"/>
+</suite>
+<statistics>
+<total>
+<stat pass="1" fail="0" skip="0">All Tests</stat>
+</total>
+<tag>
+</tag>
+<suite>
+<stat pass="1" fail="0" skip="0" id="s1" name="Tmp">Tmp</stat>
+<stat pass="1" fail="0" skip="0" id="s1-s1" name="Tests">Tmp.Tests</stat>
+</suite>
+</statistics>
+<errors>
+</errors>
+</robot>

--- a/tests/outputs/output_with_latest_robot/third.xml
+++ b/tests/outputs/output_with_latest_robot/third.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<robot generator="Robot 7.0.1 (Python 3.11.1 on darwin)" generated="2024-12-06T09:41:12.426434" rpa="false" schemaversion="5">
+<suite id="s1" name="Tmp" source="/Users/mkorpela/workspace/pabot/tmp">
+<suite id="s1-s1" name="Tests" source="/Users/mkorpela/workspace/pabot/tmp/tests.robot">
+<test id="s1-s1-t1" name="Third" line="14">
+<kw name="Log" owner="BuiltIn">
+<msg time="2024-12-06T09:41:12.584151" level="INFO">this is third</msg>
+<arg>this is third</arg>
+<doc>Logs the given message with the given level.</doc>
+<status status="PASS" start="2024-12-06T09:41:12.583145" elapsed="0.001006"/>
+</kw>
+<kw name="Sleep" owner="BuiltIn">
+<msg time="2024-12-06T09:41:13.639363" level="INFO">Slept 1 second.</msg>
+<arg>1s</arg>
+<doc>Pauses the test executed for the given time.</doc>
+<status status="PASS" start="2024-12-06T09:41:12.585379" elapsed="1.072033"/>
+</kw>
+<kw name="Log" owner="BuiltIn">
+<msg time="2024-12-06T09:41:13.660512" level="INFO">bruut</msg>
+<arg>bruut</arg>
+<doc>Logs the given message with the given level.</doc>
+<status status="PASS" start="2024-12-06T09:41:13.659485" elapsed="0.002028"/>
+</kw>
+<status status="PASS" start="2024-12-06T09:41:12.579960" elapsed="1.081553"/>
+</test>
+<status status="PASS" start="2024-12-06T09:41:12.572945" elapsed="1.109641"/>
+</suite>
+<status status="PASS" start="2024-12-06T09:41:12.481972" elapsed="1.206628"/>
+</suite>
+<statistics>
+<total>
+<stat pass="1" fail="0" skip="0">All Tests</stat>
+</total>
+<tag>
+</tag>
+<suite>
+<stat pass="1" fail="0" skip="0" id="s1" name="Tmp">Tmp</stat>
+<stat pass="1" fail="0" skip="0" id="s1-s1" name="Tests">Tmp.Tests</stat>
+</suite>
+</statistics>
+<errors>
+</errors>
+</robot>

--- a/tests/test_resultmerger.py
+++ b/tests/test_resultmerger.py
@@ -66,8 +66,9 @@ class ResultMergerTests(unittest.TestCase):
         self.assertEqual(result_merger.prefix("hui.txt"), "")
 
     def test_elapsed_time(self):
+        # output.xml generated based on robotframework >= 7.0 without --legacyoutput option
         if ROBOT_VERSION >= "7.0":
-            result = result_merger.merge(
+            result_1 = result_merger.merge(
                 [
                     "tests/outputs/output_with_latest_robot/first.xml",
                     "tests/outputs/output_with_latest_robot/second.xml",
@@ -77,13 +78,32 @@ class ResultMergerTests(unittest.TestCase):
                 "root",
                 [],
             )
-            visitor = ResultStats()
-            result.visit(visitor)
-            self.assertEqual("Tmp", result.suite.name)
-            self.assertEqual(1573, result.suite.elapsedtime)
-            self.assertEqual("Tests", result.suite.suites[0].name)
-            self.assertEqual(1474, result.suite.suites[0].elapsedtime)
+            visitor_1 = ResultStats()
+            result_1.visit(visitor_1)
+            self.assertEqual("Tmp", result_1.suite.name)
+            self.assertEqual(1573, result_1.suite.elapsedtime)
+            self.assertEqual("Tests", result_1.suite.suites[0].name)
+            self.assertEqual(1474, result_1.suite.suites[0].elapsedtime)
+
+            # output.xml generated based on robotframework >=7.0 with --legacyoutput option
+            result_2 = result_merger.merge(
+                [
+                    "tests/outputs/first.xml",
+                    "tests/outputs/second.xml",
+                    "tests/outputs/third.xml",
+                ],
+                {'legacyoutput': True},
+                "root",
+                [],
+            )
+            visitor_2 = ResultStats()
+            result_2.visit(visitor_2)
+            self.assertEqual("Tmp", result_2.suite.name)
+            self.assertEqual(1036, result_2.suite.elapsedtime)
+            self.assertEqual("Tests", result_2.suite.suites[0].name)
+            self.assertEqual(1010, result_2.suite.suites[0].elapsedtime)
         else:
+            # output.xml generated based on robotframework < 7.0
             result = result_merger.merge(
                 [
                     "tests/outputs/first.xml",
@@ -93,6 +113,7 @@ class ResultMergerTests(unittest.TestCase):
                 {},
                 "root",
                 [],
+                True
             )
             visitor = ResultStats()
             result.visit(visitor)

--- a/tests/test_resultmerger.py
+++ b/tests/test_resultmerger.py
@@ -1,11 +1,8 @@
 import unittest
-import time
 import os
-import tempfile
-import shutil
-import random
 import pabot.result_merger as result_merger
 from robot.result.visitor import ResultVisitor
+from robot import __version__ as ROBOT_VERSION
 
 
 class ResultStats(ResultVisitor):
@@ -68,6 +65,41 @@ class ResultMergerTests(unittest.TestCase):
         self.assertEqual(result_merger.prefix(os.path.join("koo", "foo.bar")), "koo")
         self.assertEqual(result_merger.prefix("hui.txt"), "")
 
+    def test_elapsed_time(self):
+        if ROBOT_VERSION >= "7.0":
+            result = result_merger.merge(
+                [
+                    "tests/outputs/output_with_latest_robot/first.xml",
+                    "tests/outputs/output_with_latest_robot/second.xml",
+                    "tests/outputs/output_with_latest_robot/third.xml",
+                ],
+                {},
+                "root",
+                [],
+            )
+            visitor = ResultStats()
+            result.visit(visitor)
+            self.assertEqual("Tmp", result.suite.name)
+            self.assertEqual(1573, result.suite.elapsedtime)
+            self.assertEqual("Tests", result.suite.suites[0].name)
+            self.assertEqual(1474, result.suite.suites[0].elapsedtime)
+        else:
+            result = result_merger.merge(
+                [
+                    "tests/outputs/first.xml",
+                    "tests/outputs/second.xml",
+                    "tests/outputs/third.xml",
+                ],
+                {},
+                "root",
+                [],
+            )
+            visitor = ResultStats()
+            result.visit(visitor)
+            self.assertEqual("Tmp", result.suite.name)
+            self.assertEqual(1036, result.suite.elapsedtime)
+            self.assertEqual("Tests", result.suite.suites[0].name)
+            self.assertEqual(1010, result.suite.suites[0].elapsedtime)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
After robotframework 7.0, the time format of output.xml was changed, end_time is removed and replaced with elapsed, the merger method cannot handle new format correctly, only it picks the elapsed time of first suite fromthe pabot_results as the total elapsed time.

#Fixes593