### PR TITLE
Fix `--runemptysuite` not working for dynamic empty suite

### DIFF
--- a/src/pabot/pabot.py
+++ b/src/pabot/pabot.py
@@ -1296,6 +1296,8 @@ def _options_for_rebot(options, start_time_string, end_time_string):
     rebot_options["include"] = []
     if ROBOT_VERSION >= "2.8":
         options["monitormarkers"] = "off"
+    if rebot_options.get("runemptysuite"):
+        rebot_options["processemptysuite"] = True
     for key in [
         "console",
         "consolemarkers",


### PR DESCRIPTION
* ws/empty1.robot
``` robot
*** Settings ***
Library         DataDriver    file=ws/foo.json    delimiter=comma

*** Test Cases ***
example
    [Template]    My Kw
*** Keywords ***
my kw
     No Operation
```
* ws/empty2.robot
``` robot
*** Settings ***
Library         DataDriver    file=ws/foo.json    delimiter=comma

*** Test Cases ***
example
    [Template]    My Kw
*** Keywords ***
my kw
     No Operation
```
* ws/empty1.robot
``` robot
*** Settings ***
Library         DataDriver    file=ws/foo.json    delimiter=comma

*** Test Cases ***
example
    [Template]    My Kw
*** Keywords ***
my kw
     No Operation
```
* data.json
```
[]
```

* run `pabot --processes 8  --runemptysuite ws`

before fix:
Output:  /Users/jnhuang/github/pabot/output.xml
[ ERROR ] Suite 'Ws' contains no tests after model modifiers.

Try --help for usage information. ...

after fix:
no errors raised, generated empty report
