### PR TITLE
Enable dryrun and testlevelsplit to work together

### DIFF
--- a/src/pabot/pabot.py
+++ b/src/pabot/pabot.py
@@ -1867,19 +1867,28 @@ def _chunk_items(items, chunk_size):
         base_item = chunked_items[0]
         if not base_item:
             continue
-        execution_items = SuiteItems([item.execution_item for item in chunked_items])
-        chunked_item = QueueItem(
-            base_item.datasources,
-            base_item.outs_dir,
-            base_item.options,
-            execution_items,
-            base_item.command,
-            base_item.verbose,
-            (base_item.argfile_index, base_item.argfile),
-            processes=base_item.processes,
-            timeout=base_item.timeout,
-        )
-        yield chunked_item
+        if type(base_item.execution_item) == TestItem:
+            for item in chunked_items:
+                chunked_item = _queue_item(base_item, item.execution_item)
+                yield chunked_item
+        else:
+            execution_items = SuiteItems([item.execution_item for item in chunked_items])
+            chunked_item = _queue_item(base_item, execution_items)
+            yield chunked_item
+
+
+def _queue_item(base_item, execution_items):
+    return QueueItem(
+        base_item.datasources,
+        base_item.outs_dir,
+        base_item.options,
+        execution_items,
+        base_item.command,
+        base_item.verbose,
+        (base_item.argfile_index, base_item.argfile),
+        processes=base_item.processes,
+        timeout=base_item.timeout,
+    )
 
 
 def _find_ending_level(name, group):

--- a/src/pabot/pabot.py
+++ b/src/pabot/pabot.py
@@ -1867,7 +1867,7 @@ def _chunk_items(items, chunk_size):
         base_item = chunked_items[0]
         if not base_item:
             continue
-        if type(base_item.execution_item) == TestItem:
+        if isinstance(base_item.execution_item, TestItem):
             for item in chunked_items:
                 chunked_item = _queue_item(base_item, item.execution_item)
                 yield chunked_item


### PR DESCRIPTION
During dryrun execution item discovery, fix issue that occurs when testlevelsplit is used and therefore the execution items should be of type TestItem and not SuiteItem(s).

Fixes #623 