### PR TITLE
Support rerunfailedsuites

### DIFF
--- a/src/pabot/execution_items.py
+++ b/src/pabot/execution_items.py
@@ -212,6 +212,8 @@ class TestItem(RunnableItem):
         def modify_options_for_executor(self, options):
             if "rerunfailed" in options:
                 del options["rerunfailed"]
+            if "rerunfailedsuites" in options:
+                del options["rerunfailedsuites"]
             name = self.name
             for char in ["[", "?", "*"]:
                 name = name.replace(char, "[" + char + "]")
@@ -222,6 +224,8 @@ class TestItem(RunnableItem):
         def modify_options_for_executor(self, options):
             if "rerunfailed" in options:
                 del options["rerunfailed"]
+            if "rerunfailedsuites" in options:
+                del options["rerunfailedsuites"]
 
     def difference(self, from_items):
         # type: (List[ExecutionItem]) -> List[ExecutionItem]

--- a/src/pabot/pabot.py
+++ b/src/pabot/pabot.py
@@ -1357,6 +1357,7 @@ def _options_for_rebot(options, start_time_string, end_time_string):
         "randomize",
         "runemptysuite",
         "rerunfailed",
+        "rerunfailedsuites",
         "skip",
         "skiponfailure",
         "skipteardownonexit",

--- a/tests/test_pabot.py
+++ b/tests/test_pabot.py
@@ -390,6 +390,12 @@ class PabotTests(unittest.TestCase):
         item.modify_options_for_executor(opts)
         self.assertTrue("rerunfailed" not in opts)
 
+    def test_test_item_removes_rerunfailedsuites_option(self):
+        item = t("Some test")
+        opts = {"rerunfailedsuites": []}
+        item.modify_options_for_executor(opts)
+        self.assertTrue("rerunfailedsuites" not in opts)
+
     def test_fix_items_splits_to_tests_when_suite_after_test_from_that_suite(self):
         expected_items = [t("s.t1"), t("s.t2")]
         items = [t("s.t1"), s("s", tests=["s.t1", "s.t2"])]


### PR DESCRIPTION
Support the robot framework command line option to re-execute failed test suites
Fixing:
https://github.com/mkorpela/pabot/issues/510
Error Invalid option 'rerunfailedsuites'"

Fixes #510 