### PR TITLE
bugfix: Fix false positives in _check_ordering when using --suite with higher-level suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ There different possibilities to influence the execution:
   * The order of suites can be changed.
   * If a directory (or a directory structure) should be executed sequentially, add the directory suite name to a row as a ```--suite``` option.
   * If the base suite name is changing with robot option [```--name / -N```](https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#setting-the-name) you can also give partial suite name without the base suite.
-  * You can add a line with text  to force executor to wait until all previous suites have been executed.
+  * You can add a line with text `#WAIT` to force executor to wait until all previous suites have been executed.
   * You can group suites and tests together to same executor process by adding line `{` before the group and `}` after. Note that `#WAIT` cannot be used inside a group.
   * You can introduce dependencies using the word `#DEPENDS` after a test declaration. This keyword can be used several times if it is necessary to refer to several different tests. Please take care that in case of circular dependencies an exception will be thrown. Note that each `#WAIT` splits suites into separate execution blocks, and it's not possible to define dependencies for suites or tests that are inside another `#WAIT` block or inside another `{}` brackets.
   * Note: Within a group `{}`, neither execution order nor the `#DEPENDS` keyword currently works. This is due to limitations in Robot Framework, which is invoked within Pabot subprocesses. These limitations may be addressed in a future release of Robot Framework. For now, tests or suites within a group will be executed in the order Robot Framework discovers them — typically in alphabetical order.

--- a/src/pabot/pabot.py
+++ b/src/pabot/pabot.py
@@ -2130,7 +2130,9 @@ def _check_ordering(ordering_file, suite_names):  # type: (List[ExecutionItem], 
             if item.type in ['suite', 'test']:
                 if not any((s == item.name or s.endswith("." + item.name)) for s in list_of_suite_names):
                     # If test name is too long, it gets name ' Invalid', so skip that
-                    if item.name != ' Invalid':
+                    # Additionally, the test is skipped also if the user wants a higher-level suite to be executed sequentially by using 
+                    # the --suite option, and the given name is part of the full name of any test or suite.
+                    if item.name != ' Invalid' and not (item.type == 'suite' and any((s == item.name or s.startswith(item.name + ".")) for s in list_of_suite_names)):
                         raise DataError("%s item '%s' in --ordering file does not match suite or test names in .pabotsuitenames file.\nPlease verify content of --ordering file." % (item.type.title(), item.name))
                 number_of_tests_or_suites += 1
         if number_of_tests_or_suites > len(list_of_suite_names):


### PR DESCRIPTION
## Description

This pull request addresses the following related improvements and fixes:

- ✅ **Bug fix:** Prevents _check_ordering from incorrectly raising errors when --suite is used to select a higher-level suite that includes other tests or suites.
- ✏️ **Documentation update**: Fixed a small typo in README.md to clarify usage.
- 🧪 **Tests added**: Two new test cases were added to ensure proper validation of --suite behavior with nested suites.

### Why it matters

- This fixes pabot 4.3.0 release which may not working correctly in some cases.
- This ensures that valid use cases of --suite do not result in confusing or incorrect error messages. It also strengthens pabot's ability to validate --ordering files while still respecting legitimate test/suite structures.