### PR TITLE
Add GitHub workflow to automatically update status-type issue labels

### DIFF
--- a/.github/workflows/update-status-label.yml
+++ b/.github/workflows/update-status-label.yml
@@ -1,0 +1,108 @@
+name: Issue and PR Status Labels
+
+on:
+  issues:
+    types: [opened, closed]
+  pull_request:
+    types: [opened, edited, synchronize, closed]
+
+jobs:
+  update-status:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Set up Python (needed by GitHub Actions)
+        uses: actions/setup-python@v4
+
+      - name: Update issue and PR status
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const issueLabels = {
+              open: 'status: open',
+              completed: 'status: completed',
+              pr_submitted: 'status: pr submitted',
+              needs_review: 'status: needs review'
+            };
+
+            async function removeOldStatusLabels(issue_number) {
+              const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+                ...context.repo,
+                issue_number
+              });
+
+              for (const label of labels) {
+                if (label.name.startsWith('status:')) {
+                  try {
+                    await github.rest.issues.removeLabel({
+                      ...context.repo,
+                      issue_number,
+                      name: label.name
+                    });
+                  } catch (e) {
+                    // Label might not exist, ignore
+                  }
+                }
+              }
+            }
+
+            // Handle issues
+            if (context.eventName === 'issues') {
+              const issueNumber = context.payload.issue.number;
+              await removeOldStatusLabels(issueNumber);
+
+              if (context.payload.action === 'opened') {
+                await github.rest.issues.addLabels({
+                  ...context.repo,
+                  issue_number: issueNumber,
+                  labels: [issueLabels.open]
+                });
+              } else if (context.payload.action === 'closed') {
+                await github.rest.issues.addLabels({
+                  ...context.repo,
+                  issue_number: issueNumber,
+                  labels: [issueLabels.completed]
+                });
+              }
+            }
+
+            // Handle pull requests
+            if (context.eventName === 'pull_request') {
+              const pr = context.payload.pull_request;
+              const prNumber = pr.number;
+
+              // Only remove labels from the PR itself (optional)
+              await removeOldStatusLabels(prNumber);
+
+              if (['opened', 'edited', 'synchronize'].includes(context.payload.action)) {
+                const body = pr.body || "";
+                const issueMatch = body.match(/(?:fixes|closes|resolves)\s+#(\d+)/i);
+
+                if (issueMatch) {
+                  const issueNumber = parseInt(issueMatch[1], 10);
+                  await removeOldStatusLabels(issueNumber);
+                  await github.rest.issues.addLabels({
+                    ...context.repo,
+                    issue_number: issueNumber,
+                    labels: [issueLabels.pr_submitted]
+                  });
+                } else {
+                  // PR is open but not linked to issue
+                  await github.rest.issues.addLabels({
+                    ...context.repo,
+                    issue_number: prNumber,
+                    labels: [issueLabels.needs_review]
+                  });
+                }
+
+              } else if (context.payload.action === 'closed' && pr.merged) {
+                await github.rest.issues.addLabels({
+                  ...context.repo,
+                  issue_number: prNumber,
+                  labels: [issueLabels.completed]
+                });
+              }
+            }

--- a/.github/workflows/update-status-label.yml
+++ b/.github/workflows/update-status-label.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Set up Python (needed by GitHub Actions)
         uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
 
       - name: Update issue and PR status
         uses: actions/github-script@v6
@@ -43,13 +45,13 @@ jobs:
                       name: label.name
                     });
                   } catch (e) {
-                    // Label might not exist, ignore
+                    // ignore errors
                   }
                 }
               }
             }
 
-            // Handle issues
+            // Handle issues only (own labels)
             if (context.eventName === 'issues') {
               const issueNumber = context.payload.issue.number;
               await removeOldStatusLabels(issueNumber);
@@ -69,35 +71,28 @@ jobs:
               }
             }
 
-            // Handle pull requests
+            // Handle PR labels only (no external issue modifications)
             if (context.eventName === 'pull_request') {
               const pr = context.payload.pull_request;
               const prNumber = pr.number;
-
-              // Only remove labels from the PR itself (optional)
               await removeOldStatusLabels(prNumber);
 
               if (['opened', 'edited', 'synchronize'].includes(context.payload.action)) {
                 const body = pr.body || "";
-                const issueMatch = body.match(/(?:fixes|closes|resolves)\s+#(\d+)/i);
-
-                if (issueMatch) {
-                  const issueNumber = parseInt(issueMatch[1], 10);
-                  await removeOldStatusLabels(issueNumber);
+                const linkedIssue = body.match(/(?:fixes|closes|resolves)\s+#\d+/i);
+                if (linkedIssue) {
                   await github.rest.issues.addLabels({
                     ...context.repo,
-                    issue_number: issueNumber,
+                    issue_number: prNumber,
                     labels: [issueLabels.pr_submitted]
                   });
                 } else {
-                  // PR is open but not linked to issue
                   await github.rest.issues.addLabels({
                     ...context.repo,
                     issue_number: prNumber,
                     labels: [issueLabels.needs_review]
                   });
                 }
-
               } else if (context.payload.action === 'closed' && pr.merged) {
                 await github.rest.issues.addLabels({
                   ...context.repo,


### PR DESCRIPTION
### Description:

This PR introduces a new GitHub Actions workflow that automatically updates the status-type labels (e.g., `status: open`, `status: in progress`, `status: completed`) on issues.
The goal is to ensure issue labels remain in sync with their actual state without requiring manual intervention.

Key points:

- Adds a workflow file under .github/workflows/
- Detects issue activity and updates labels accordingly
- Helps maintain consistency and visibility in issue tracking

### Motivation:
Manually updating status labels can be error-prone and time-consuming. Automating this task improves project hygiene and saves contributor time.