### PR TITLE
ci: Add missing packaging module import to release-workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,7 @@ jobs:
 
       - name: Validate PEP 440 version
         run: |
+          python -m pip install --upgrade packaging
           python - <<EOF
           from packaging.version import Version
           Version("${{ steps.tag.outputs.version }}")


### PR DESCRIPTION
## Summary
CI linux does not have packaging automatically installed.
