### PR TITLE
ci: Fix pabot --version check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,7 +159,7 @@ jobs:
       - name: Smoke test wheel
         run: |
           pip install dist/*.whl
-          pabot --version
+          python -m pabot.pabot --version
 
   publish-release:
     needs: [validate-version, run-tests, build, smoke-test]


### PR DESCRIPTION
## Summary
Trying to fix some CI daemon locks issue when checking pabot --version
