### PR TITLE
ci: Fix release smoke test to wait 251 as exit code after --version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,6 +160,12 @@ jobs:
         run: |
           pip install dist/*.whl
           python -m pabot.pabot --version
+          EXIT_CODE=$?
+          echo "Pabot exit code: $EXIT_CODE"
+          if [ $EXIT_CODE -ne 251 ]; then
+            echo "Unexpected exit code!"
+            exit $EXIT_CODE
+          fi
 
   publish-release:
     needs: [validate-version, run-tests, build, smoke-test]


### PR DESCRIPTION
## Summary
pabot's exit code now follows RF, so 0 is reserved for all tests passed case.
