### PR TITLE
fix: prevent KeyError: 'ordering' when using --chunk

### DIFF
--- a/src/pabot/pabot.py
+++ b/src/pabot/pabot.py
@@ -2720,8 +2720,8 @@ def _group_suites(outs_dir, datasources, options, pabot_args):
     ordered_suites = _preserve_order(suite_names, ordering_arg_with_sleep)
     shard_suites = solve_shard_suites(ordered_suites, pabot_args)
     grouped_suites = (
-        _chunked_suite_names(shard_suites, pabot_args["processes"])
-        if pabot_args["chunk"] and not pabot_args["ordering"]
+        _chunked_suite_names(shard_suites, pabot_args.get("processes"))
+        if pabot_args.get("chunk") and not pabot_args.get("ordering")
         else _group_by_wait(_group_by_groups(shard_suites))
     )
     grouped_by_depend = _all_grouped_suites_by_depend(grouped_suites)


### PR DESCRIPTION
## Summary
Prevent pabot crash when `--ordering` is not set but `--chunk` is.

## Related issues
Fixes #707 

## Checklist
- [ ] Tests added or updated
- [ ] Documentation updated
- [x] Backwards compatibility considered
