### PR TITLE
Bugfix: Pabot console output not always in real time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,11 +57,5 @@ jobs:
           echo "pytest: $(pytest --version)"
           echo "pip: $(pip --version)"
 
-      - name: Test Pabot console streaming multiple times
-        run: |
-          echo "Running realtime Pabot streaming test..."
-          pytest -s tests/test_pabot_console_streaming.py
-          echo "Finished!"
-
       - name: Run tests
         run: pytest tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,11 +59,9 @@ jobs:
 
       - name: Test Pabot console streaming multiple times
         run: |
-          echo "Running realtime Pabot streaming test 5 times..."
-          for i in {1..5}; do
-            echo "Run #$i"
-            pytest -s tests/test_pabot_console_streaming.py
-          done
+          echo "Running realtime Pabot streaming test..."
+          pytest -s tests/test_pabot_console_streaming.py
+          echo "Finished!"
 
       - name: Run tests
         run: pytest tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,5 +57,13 @@ jobs:
           echo "pytest: $(pytest --version)"
           echo "pip: $(pip --version)"
 
+      - name: Test Pabot console streaming multiple times
+        run: |
+          echo "Running realtime Pabot streaming test 5 times..."
+          for i in {1..5}; do
+            echo "Run #$i"
+            pytest -s tests/test_pabot_console_streaming.py
+          done
+
       - name: Run tests
         run: pytest tests

--- a/src/pabot/writer.py
+++ b/src/pabot/writer.py
@@ -152,9 +152,9 @@ class MessageWriter:
                         self.console.dot(self._wrap_with(color, "s"))
                     else:
                         self.console.newline()
-                        print(self._wrap_with(color, message))
+                        print(self._wrap_with(color, message), flush=True)
                 else:
-                    print(self._wrap_with(color, message))
+                    print(self._wrap_with(color, message), flush=True)
                     
     def _writer(self):
         log_f = None

--- a/tests/ci/stream.robot
+++ b/tests/ci/stream.robot
@@ -1,0 +1,42 @@
+*** Settings ***
+Test Template    Log Loop
+
+*** Test Cases ***
+Stream 01    _
+Stream 02    _
+Stream 03    _
+Stream 04    _
+Stream 05    _
+Stream 06    _
+Stream 07    _
+Stream 08    _
+Stream 09    _
+Stream 10    _
+Stream 11    _
+Stream 12    _
+Stream 13    _
+Stream 14    _
+Stream 15    _
+Stream 16    _
+Stream 17    _
+Stream 18    _
+Stream 19    _
+Stream 20    _
+Stream 21    _
+Stream 22    _
+Stream 23    _
+Stream 24    _
+Stream 25    _
+Stream 26    _
+Stream 27    _
+Stream 28    _
+Stream 29    _
+Stream 30    _
+
+*** Keywords ***
+Log Loop
+    [Arguments]    ${dummy}
+    FOR    ${i}    IN RANGE    5
+        Log To Console    step ${i}
+        Sleep    0.1s
+    END

--- a/tests/test_pabot_console_streaming.py
+++ b/tests/test_pabot_console_streaming.py
@@ -1,63 +1,49 @@
-import threading
-import time
-from pabot.writer import get_writer
+import unittest
+import subprocess
+import re
+from datetime import datetime
 
-def worker(writer, start, end, delay=0.1):
-    """Simulates a single worker writing log output with a small delay."""
-    for i in range(start, end):
-        writer.write(f"step {i}")
-        time.sleep(delay)
+class TestPabotRealtimeLogging(unittest.TestCase):
+    def test_pabot_log_delay(self):
+        pabot_cmd = [
+            "pabot",
+            "--testlevelsplit",
+            "tests/ci"
+        ]
 
-
-def test_pabot_console_streaming_realtime():
-    """
-    Tests Pabot console streaming with multiple "workers".
-    Fails if output is excessively buffered (i.e., not near-real-time).
-    """
-    # Get the MessageWriter directly (not ThreadSafeWriter)
-    # Use console_type='none' to capture logs in memory instead of printing
-    writer = get_writer(console_type="none")
-
-    # List to capture timestamps of each log
-    log_times = []
-
-    # Override writer.write to capture timestamps
-    original_write = writer.write
-    def capture_write(msg, color=None, level="info"):
-        log_times.append(time.time())
-        original_write(msg, color=color, level=level)
-
-    writer.write = capture_write
-
-    threads = []
-    num_workers = 8
-    steps_per_worker = 100
-    sleep_delay = 0.05
-    max_interval_threshold = 0.1  # Max allowed interval between log messages (in seconds)
-
-    # Start worker threads
-    for w in range(num_workers):
-        t = threading.Thread(
-            target=worker,
-            args=(writer, w * steps_per_worker, (w + 1) * steps_per_worker, sleep_delay),
+        process = subprocess.Popen(
+            pabot_cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            bufsize=1,
+            universal_newlines=True
         )
-        t.start()
-        threads.append(t)
 
-    # Wait for all threads to finish
-    for t in threads:
-        t.join()
+        timestamp_pattern = re.compile(r"^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+)")
 
-    # Ensure all queued messages are flushed
-    writer.flush(timeout=5)
-    # Stop the background writer thread
-    writer.stop()
+        max_allowed_delay = 0.5  # seconds
+        delays = []
 
-    # Calculate intervals between log messages
-    intervals = [t2 - t1 for t1, t2 in zip(log_times, log_times[1:])]
-    max_interval = max(intervals) if intervals else 0.0
+        for line in process.stdout:
+            line = line.rstrip()
+            match = timestamp_pattern.search(line)
+            now = datetime.now()
 
-    print(f"Max interval between log messages: {max_interval:.3f}s")
+            if match:
+                log_time_str = match.group(1)
+                log_time = datetime.strptime(log_time_str, "%Y-%m-%d %H:%M:%S.%f")
+                delta = (now - log_time).total_seconds()
+                delays.append(delta)
+                print(f"{now.isoformat()} | {line} | delay: {delta:.6f}s")
+            else:
+                print(f"{now.isoformat()} | {line} | delay: N/A")
 
-    # Fail if any interval is too long (i.e., buffering happened)
-    assert max_interval < max_interval_threshold, f"Console output appears buffered, max interval={max_interval:.3f}s"
+        process.wait()
+
+        # Assert that all log delays are within the allowed threshold
+        for delta in delays:
+            self.assertLessEqual(delta, max_allowed_delay, 
+                f"Log delay too high: {delta:.6f}s")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pabot_console_streaming.py
+++ b/tests/test_pabot_console_streaming.py
@@ -1,0 +1,63 @@
+import threading
+import time
+from pabot.writer import get_writer
+
+def worker(writer, start, end, delay=0.1):
+    """Simulates a single worker writing log output with a small delay."""
+    for i in range(start, end):
+        writer.write(f"step {i}")
+        time.sleep(delay)
+
+
+def test_pabot_console_streaming_realtime():
+    """
+    Tests Pabot console streaming with multiple "workers".
+    Fails if output is excessively buffered (i.e., not near-real-time).
+    """
+    # Get the MessageWriter directly (not ThreadSafeWriter)
+    # Use console_type='none' to capture logs in memory instead of printing
+    writer = get_writer(console_type="none")
+
+    # List to capture timestamps of each log
+    log_times = []
+
+    # Override writer.write to capture timestamps
+    original_write = writer.write
+    def capture_write(msg, color=None, level="info"):
+        log_times.append(time.time())
+        original_write(msg, color=color, level=level)
+
+    writer.write = capture_write
+
+    threads = []
+    num_workers = 8
+    steps_per_worker = 100
+    sleep_delay = 0.05
+    max_interval_threshold = 0.1  # Max allowed interval between log messages (in seconds)
+
+    # Start worker threads
+    for w in range(num_workers):
+        t = threading.Thread(
+            target=worker,
+            args=(writer, w * steps_per_worker, (w + 1) * steps_per_worker, sleep_delay),
+        )
+        t.start()
+        threads.append(t)
+
+    # Wait for all threads to finish
+    for t in threads:
+        t.join()
+
+    # Ensure all queued messages are flushed
+    writer.flush(timeout=5)
+    # Stop the background writer thread
+    writer.stop()
+
+    # Calculate intervals between log messages
+    intervals = [t2 - t1 for t1, t2 in zip(log_times, log_times[1:])]
+    max_interval = max(intervals) if intervals else 0.0
+
+    print(f"Max interval between log messages: {max_interval:.3f}s")
+
+    # Fail if any interval is too long (i.e., buffering happened)
+    assert max_interval < max_interval_threshold, f"Console output appears buffered, max interval={max_interval:.3f}s"


### PR DESCRIPTION
## Summary
Add `flush=True `to console prints to make sure that console output is in real time even when pabot is running in CI or via subprocess.

## Related issues
Fixes #711 

## Checklist
- [x] Tests added or updated
- [x] Documentation updated
- [x] Backwards compatibility considered
