### PR TITLE
Fix/writer flush condition doc

### DIFF
--- a/src/pabot/writer.py
+++ b/src/pabot/writer.py
@@ -4,6 +4,8 @@ import sys
 import os
 import time
 
+_DEFAULT_FLUSH_TIMEOUT = 5.0
+
 class Color:
     RED = "\033[91m"
     GREEN = "\033[92m"
@@ -95,9 +97,15 @@ class MessageWriter:
         if log_file:
             os.makedirs(os.path.dirname(log_file), exist_ok=True)
         self._stop_event = threading.Event()
+        self._drain_cv = threading.Condition()  # Signals flush() waiters when the queue drains
         self.thread = threading.Thread(target=self._writer)
         self.thread.daemon = False
         self.thread.start()
+
+    def _notify_drained(self) -> None:
+        if self.queue.unfinished_tasks == 0:
+            with self._drain_cv:
+                self._drain_cv.notify_all()
 
     def _is_output_coloring_supported(self):
         return sys.stdout.isatty() and os.name in Color.SUPPORTED_OSES
@@ -184,12 +192,14 @@ class MessageWriter:
 
                 if message is None:
                     self.queue.task_done()
+                    self._notify_drained()
                     break
 
                 message = message.rstrip("\n")
 
                 buffer.append((message, color, level))
                 self.queue.task_done()
+                self._notify_drained()
 
                 # Batch full → flush
                 if len(buffer) >= BATCH_SIZE:
@@ -222,17 +232,40 @@ class MessageWriter:
         except queue.Full:
             pass  # drop
         
-    def flush(self, timeout=5):
-        end = time.time() + timeout
-        try:
-            while time.time() < end:
-                if self.queue.unfinished_tasks == 0:
-                    return True
-                time.sleep(0.05)
-            return False
-        except KeyboardInterrupt:
-            # Allow tests/cli to interrupt flushing
-            return False
+    def flush(self, timeout=_DEFAULT_FLUSH_TIMEOUT):
+        """Wait for queued messages to be written.
+
+        The writer thread drains `self.queue` and calls `task_done()` for each
+        item processed. This method waits until `unfinished_tasks == 0`.
+
+        Uses a Condition to avoid sleep-based polling, which can accumulate large
+        delays when flush() is invoked repeatedly.
+
+        Args:
+            timeout: Maximum seconds to wait. If None, wait indefinitely.
+
+        Returns:
+            True if the queue drained before the timeout (or stop was requested),
+            False if the timeout elapsed or a KeyboardInterrupt happened.
+        """
+        if self._stop_event.is_set():
+            return True
+
+        if timeout is None:
+            try:
+                self.queue.join()
+            except KeyboardInterrupt:
+                return False
+            return True
+
+        deadline = time.time() + float(timeout)
+        with self._drain_cv:
+            while self.queue.unfinished_tasks != 0:
+                remaining = deadline - time.time()
+                if remaining <= 0:
+                    return False
+                self._drain_cv.wait(timeout=remaining)
+        return True
 
     def stop(self):
         """

--- a/tests/test_main_program_repeated_runs.py
+++ b/tests/test_main_program_repeated_runs.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import tempfile
+import textwrap
+import time
+
+import pabot.pabot
+
+
+def _write_minimal_suite(tmpdir: str) -> str:
+    suite_path = os.path.join(tmpdir, "smoke.robot")
+    with open(suite_path, "w", encoding="utf-8") as f:
+        f.write(
+            textwrap.dedent(
+                """
+                *** Settings ***
+                Suite Setup    No Operation
+
+                *** Test Cases ***
+                Test 1
+                    No Operation
+                Test 2
+                    No Operation
+                """
+            ).strip()
+            + "\n"
+        )
+    return suite_path
+
+
+def test_main_program_repeated_runs_does_not_slow_down():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        suite_path = _write_minimal_suite(tmpdir)
+
+        durations: list[float] = []
+        for i in range(4):
+            outdir = os.path.join(tmpdir, f"out_{i}")
+            args = ["--pabotlib", "--pabotlibport", "0", "--outputdir", outdir, suite_path]
+
+            t0 = time.perf_counter()
+            exit_code = int(pabot.pabot.main_program(args))
+            durations.append(time.perf_counter() - t0)
+
+            assert exit_code == 0
+
+        # Regression guard: previously iter 3+ could jump to ~25s.
+        assert max(durations) < 10.0
+        assert durations[2] < max(durations[0], durations[1]) * 5 + 1.0

--- a/tests/test_messagewriter_flush_unit.py
+++ b/tests/test_messagewriter_flush_unit.py
@@ -1,0 +1,50 @@
+import os
+import threading
+import time
+
+from pabot.writer import MessageWriter
+
+
+def test_messagewriter_flush_blocks_until_queue_drains(tmp_path, monkeypatch):
+    writer = MessageWriter(log_file=str(tmp_path / "pabot.log"), console_type="none")
+    stop_event = threading.Event()
+
+    original_flush_batch = writer._flush_batch
+
+    def blocking_flush_batch(batch, log_f):
+        stop_event.wait(timeout=5)
+        return original_flush_batch(batch, log_f)
+
+    monkeypatch.setattr(writer, "_flush_batch", blocking_flush_batch)
+
+    try:
+        for i in range(200):
+            writer.write(f"msg-{i}", level="info")
+
+        time.sleep(0.01)
+        assert writer.queue.unfinished_tasks != 0
+
+        t0 = time.perf_counter()
+        ok1 = writer.flush(timeout=0.05)
+        assert ok1 is False
+        assert (time.perf_counter() - t0) < 0.5
+
+        stop_event.set()
+
+        t1 = time.perf_counter()
+        ok2 = writer.flush(timeout=2)
+        assert ok2 is True
+        assert (time.perf_counter() - t1) < 0.5
+
+    finally:
+        writer.stop()
+
+
+def test_messagewriter_flush_timeout_none_waits_until_drained(tmp_path):
+    writer = MessageWriter(log_file=str(tmp_path / "pabot.log"), console_type="none")
+    try:
+        for i in range(10):
+            writer.write(f"msg-{i}", level="info")
+        assert writer.flush(timeout=None) is True
+    finally:
+        writer.stop()


### PR DESCRIPTION
## Summary
Fix the repeated in-process slowdown by replacing sleep-based polling in `MessageWriter.flush()` with a Condition-based wait that is notified when the writer queue drains.

Detailed description:
The slowdown came from `MessageWriter.flush()` using sleep-based polling of `queue.unfinished_tasks` (sleeping repeatedly up to the timeout) when draining log output. When pabot is run repeatedly in the same Python process, that polling path gets hit many times during shutdown and the accumulated sleeps create a large “slope” (iter 3+ jumping to ~20–25s).

The fix replaces polling with proper synchronization:
- The writer thread already calls `queue.task_done()` for each processed item.
- Add a `Condition` (`_drain_cv`) used to signal “queue drained” to any `flush()` waiters.
- After each `task_done()` (and at sentinel shutdown), the writer thread calls `_notify_drained()` which `notify_all()`’s when `unfinished_tasks == 0`.
- `flush(timeout=...)` now waits on the condition until `unfinished_tasks` reaches 0 or the timeout expires (no `time.sleep()` loop).
- `timeout=None` keeps prior semantics via `queue.join()`.

Tests:
- A new repeated `main_program()` regression test runs pabot multiple times in-process and asserts the historical slope doesn’t return (fails on old code, passes with the fix).
- Focused unit tests cover `flush(timeout=None)` and the “blocked drain → timeout False; released drain → True quickly” lifecycle.

## Related issues
Fixes #724 

## Checklist
- [x] Tests added or updated
- [ ] Documentation updated
- [x] Backwards compatibility considered