### PR TITLE
Bugfix executor numbering

### DIFF
--- a/src/pabot/pabot.py
+++ b/src/pabot/pabot.py
@@ -125,9 +125,6 @@ _NOT_COMPLETED_INDEXES = []  # type: List[int]
 
 # Thread-local storage for tracking executor number assigned to each thread
 _EXECUTOR_THREAD_LOCAL = threading.local()
-# Next executor number to assign (incremented each time a task is submitted)
-_EXECUTOR_COUNTER = 0
-_EXECUTOR_COUNTER_LOCK = threading.Lock()
 # Maximum number of executors (workers in the thread pool)
 _MAX_EXECUTORS = 1
 # Size of the current parallel execution batch
@@ -253,15 +250,6 @@ class Color:
     YELLOW = "\033[93m"
 
 
-def _get_next_executor_num():
-    """Get the next executor number in round-robin fashion."""
-    global _EXECUTOR_COUNTER, _MAX_EXECUTORS
-    with _EXECUTOR_COUNTER_LOCK:
-        executor_num = _EXECUTOR_COUNTER % _MAX_EXECUTORS
-        _EXECUTOR_COUNTER += 1
-    return executor_num
-
-
 def _allocate_executor():
     """Allocate next available executor number from the pool."""
     global _FREE_EXECUTORS, _MAX_EXECUTORS
@@ -287,8 +275,8 @@ def _set_executor_num(executor_num):
 
 
 def _get_executor_num():
-    """Get the executor number for the current thread. Note that indexing starts from 1."""
-    return getattr(_EXECUTOR_THREAD_LOCAL, "executor_num", 0) + 1
+    """Get the executor number for the current thread."""
+    return getattr(_EXECUTOR_THREAD_LOCAL, "executor_num", 0)
 
 
 def _execute_item_with_executor_tracking(item):
@@ -1800,12 +1788,11 @@ def _parallel_execute_dynamic(
 ):
     # Signal handler is already set in main_program, no need to set it again
     # Just use the thread pool without managing signals
-    global _MAX_EXECUTORS, _EXECUTOR_COUNTER, _CURRENT_BATCH_SIZE, _FREE_EXECUTORS
+    global _MAX_EXECUTORS, _CURRENT_BATCH_SIZE, _FREE_EXECUTORS
 
     _CURRENT_BATCH_SIZE = len(items)
     max_processes = processes or _CURRENT_BATCH_SIZE
     _MAX_EXECUTORS = max_processes
-    _EXECUTOR_COUNTER = 0  # Reset executor counter for each parallel execution batch
     _FREE_EXECUTORS = list(range(max_processes))  # Initialize free executor pool
     pool = ThreadPool(max_processes)
 
@@ -1887,11 +1874,10 @@ def _parallel_execute(
     items, processes, datasources, outs_dir, opts_for_run, pabot_args
 ):
     # Signal handler is already set in main_program, no need to set it again
-    global _MAX_EXECUTORS, _EXECUTOR_COUNTER, _CURRENT_BATCH_SIZE, _FREE_EXECUTORS
+    global _MAX_EXECUTORS, _CURRENT_BATCH_SIZE, _FREE_EXECUTORS
     _CURRENT_BATCH_SIZE = len(items)
     max_workers = processes or _CURRENT_BATCH_SIZE
     _MAX_EXECUTORS = max_workers
-    _EXECUTOR_COUNTER = 0  # Reset executor counter for each parallel execution batch
     _FREE_EXECUTORS = list(range(max_workers))  # Initialize free executor pool
     pool = ThreadPool(max_workers)
     results = [pool.map_async(_execute_item_with_executor_tracking, items, 1)]

--- a/src/pabot/pabot.py
+++ b/src/pabot/pabot.py
@@ -132,6 +132,9 @@ _EXECUTOR_COUNTER_LOCK = threading.Lock()
 _MAX_EXECUTORS = 1
 # Size of the current parallel execution batch
 _CURRENT_BATCH_SIZE = 0
+# Pool of free executor numbers (for proper reuse of executor slots)
+_FREE_EXECUTORS = []  # type: List[int]
+_EXECUTOR_ALLOCATION_LOCK = threading.Lock()
 
 _ROBOT_EXTENSIONS = [
     ".html",
@@ -259,21 +262,47 @@ def _get_next_executor_num():
     return executor_num
 
 
+def _allocate_executor():
+    """Allocate next available executor number from the pool."""
+    global _FREE_EXECUTORS, _MAX_EXECUTORS
+    with _EXECUTOR_ALLOCATION_LOCK:
+        if not _FREE_EXECUTORS:
+            # Initialize pool if empty
+            _FREE_EXECUTORS = list(range(_MAX_EXECUTORS))
+        executor_num = _FREE_EXECUTORS.pop(0)  # Get first available executor
+    return executor_num
+
+
+def _release_executor(executor_num):
+    """Release executor back to the pool."""
+    global _FREE_EXECUTORS
+    with _EXECUTOR_ALLOCATION_LOCK:
+        _FREE_EXECUTORS.append(executor_num)
+        _FREE_EXECUTORS.sort()  # Keep sorted for predictability
+
+
 def _set_executor_num(executor_num):
     """Set the executor number for the current thread."""
     _EXECUTOR_THREAD_LOCAL.executor_num = executor_num
 
 
 def _get_executor_num():
-    """Get the executor number for the current thread."""
-    return getattr(_EXECUTOR_THREAD_LOCAL, "executor_num", 0)
+    """Get the executor number for the current thread. Note that indexing starts from 1."""
+    return getattr(_EXECUTOR_THREAD_LOCAL, "executor_num", 0) + 1
 
 
 def _execute_item_with_executor_tracking(item):
-    """Wrapper to track executor number and call execute_and_wait_with."""
-    executor_num = _get_next_executor_num()
+    """Wrapper to track executor number and call execute_and_wait_with.
+
+    Allocates next available executor from the pool, ensuring that freed
+    executors are properly reused instead of cycling through all numbers.
+    """
+    executor_num = _allocate_executor()
     _set_executor_num(executor_num)
-    return execute_and_wait_with(item)
+    try:
+        return execute_and_wait_with(item)
+    finally:
+        _release_executor(executor_num)
 
 
 def execute_and_wait_with(item):
@@ -1771,12 +1800,13 @@ def _parallel_execute_dynamic(
 ):
     # Signal handler is already set in main_program, no need to set it again
     # Just use the thread pool without managing signals
-    global _MAX_EXECUTORS, _EXECUTOR_COUNTER, _CURRENT_BATCH_SIZE
+    global _MAX_EXECUTORS, _EXECUTOR_COUNTER, _CURRENT_BATCH_SIZE, _FREE_EXECUTORS
 
     _CURRENT_BATCH_SIZE = len(items)
     max_processes = processes or _CURRENT_BATCH_SIZE
     _MAX_EXECUTORS = max_processes
     _EXECUTOR_COUNTER = 0  # Reset executor counter for each parallel execution batch
+    _FREE_EXECUTORS = list(range(max_processes))  # Initialize free executor pool
     pool = ThreadPool(max_processes)
 
     pending = set(items)
@@ -1857,11 +1887,12 @@ def _parallel_execute(
     items, processes, datasources, outs_dir, opts_for_run, pabot_args
 ):
     # Signal handler is already set in main_program, no need to set it again
-    global _MAX_EXECUTORS, _EXECUTOR_COUNTER, _CURRENT_BATCH_SIZE
+    global _MAX_EXECUTORS, _EXECUTOR_COUNTER, _CURRENT_BATCH_SIZE, _FREE_EXECUTORS
     _CURRENT_BATCH_SIZE = len(items)
     max_workers = processes or _CURRENT_BATCH_SIZE
     _MAX_EXECUTORS = max_workers
     _EXECUTOR_COUNTER = 0  # Reset executor counter for each parallel execution batch
+    _FREE_EXECUTORS = list(range(max_workers))  # Initialize free executor pool
     pool = ThreadPool(max_workers)
     results = [pool.map_async(_execute_item_with_executor_tracking, items, 1)]
     delayed_result_append = 0
@@ -2086,7 +2117,7 @@ def _report_results(outs_dir, pabot_args, options, start_time_string, tests_root
             _write(repr(missing), level="warning")
         _write(
             (
-                f"[ " + _wrap_with(Color.RED, "ERROR") + " ] "
+                "[ " + _wrap_with(Color.RED, "ERROR") + " ] "
                 "The output, log and report files produced by Pabot are "
                 "incomplete and do not contain all test cases."
             ),
@@ -2728,7 +2759,9 @@ def _collect_exclusive_tests_recursive(suite, exclusive_test_names, suite_to_all
             exclusive_test_names.add(longname)
     suite_to_all_tests[suite.longname] = suite_tests
     for subsuite in suite.suites:
-        _collect_exclusive_tests_recursive(subsuite, exclusive_test_names, suite_to_all_tests)
+        _collect_exclusive_tests_recursive(
+            subsuite, exclusive_test_names, suite_to_all_tests
+        )
 
 
 def _scan_for_exclusive_tests(datasources, options):
@@ -2754,9 +2787,13 @@ def _scan_for_exclusive_tests(datasources, options):
         suite = builder.build(*datasources)
         settings.rpa = builder.rpa
         suite.configure(**settings.suite_config)
-        _collect_exclusive_tests_recursive(suite, exclusive_test_names, suite_to_all_tests)
+        _collect_exclusive_tests_recursive(
+            suite, exclusive_test_names, suite_to_all_tests
+        )
     except Exception as e:
-        _write("Warning: could not scan for exclusive tests: %s" % str(e), level="warning")
+        _write(
+            "Warning: could not scan for exclusive tests: %s" % str(e), level="warning"
+        )
     return exclusive_test_names, suite_to_all_tests
 
 
@@ -2871,7 +2908,9 @@ def main_program(args):
                 return 252
 
         # Detect and separate tests that must run exclusively (no parallel execution)
-        exclusive_test_names, suite_to_all_tests = _scan_for_exclusive_tests(datasources, options)
+        exclusive_test_names, suite_to_all_tests = _scan_for_exclusive_tests(
+            datasources, options
+        )
         exclusive_items = []  # type: List[ExecutionItem]
         if exclusive_test_names:
             suite_groups, exclusive_items = _separate_exclusive_items(
@@ -2893,7 +2932,12 @@ def main_program(args):
         exclusive_stages = []  # type: List[Tuple[str, List[List[ExecutionItem]]]]
         for exclusive_item in exclusive_items:
             exc_items = _create_execution_items(
-                [[exclusive_item]], datasources, outs_dir, options, opts_for_run, pabot_args
+                [[exclusive_item]],
+                datasources,
+                outs_dir,
+                options,
+                opts_for_run,
+                pabot_args,
             )
             exclusive_stages.append((exclusive_item.name, exc_items))
 

--- a/tests/test_exclusive_atest.py
+++ b/tests/test_exclusive_atest.py
@@ -32,19 +32,24 @@ ATEST_DIR = os.path.join(REPO_ROOT, "atest")
 SRC_DIR = os.path.join(REPO_ROOT, "src")
 PABOT_TAG = "pabot:exclusive"
 
-EXPECTED_EXCLUSIVE_TESTS = 3   # 1 (suite_04) + 2 (suite_05)
-EXPECTED_TOTAL_TESTS = 10      # suite_01..03: 3*2=6, suite_04: 2, suite_05: 2
+EXPECTED_EXCLUSIVE_TESTS = 3  # 1 (suite_04) + 2 (suite_05)
+EXPECTED_TOTAL_TESTS = 10  # suite_01..03: 3*2=6, suite_04: 2, suite_05: 2
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _run_pabot(output_dir, extra_args=None):
     """Run pabot against atest/ and return CompletedProcess."""
     cmd = [
-        sys.executable, "-m", "pabot.pabot",
-        "--processes", "4",
-        "--outputdir", str(output_dir),
+        sys.executable,
+        "-m",
+        "pabot.pabot",
+        "--processes",
+        "4",
+        "--outputdir",
+        str(output_dir),
     ]
     if extra_args:
         cmd.extend(extra_args)
@@ -111,6 +116,8 @@ def _overlap(a, b):
 # Tests
 # ---------------------------------------------------------------------------
 
+
+@pytest.mark.skipif(sys.platform == "win32", reason="fcntl not supported on Windows")
 def test_all_atest_tests_pass(tmp_path):
     """pabot must exit 0 and all tests in atest/ must report PASS."""
     result = _run_pabot(tmp_path)
@@ -120,8 +127,9 @@ def test_all_atest_tests_pass(tmp_path):
     )
 
     tests = _parse_tests(str(tmp_path / "output.xml"))
-    assert len(tests) == EXPECTED_TOTAL_TESTS, (
-        "Expected %d tests, found %d" % (EXPECTED_TOTAL_TESTS, len(tests))
+    assert len(tests) == EXPECTED_TOTAL_TESTS, "Expected %d tests, found %d" % (
+        EXPECTED_TOTAL_TESTS,
+        len(tests),
     )
     failed = [t["name"] for t in tests if t.get("status") == "FAIL"]
     assert not failed, "Some tests failed: %s" % failed
@@ -137,6 +145,7 @@ def test_exclusive_tests_detected_in_output(tmp_path):
     )
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="fcntl not supported on Windows")
 def test_exclusive_tests_run_alone(tmp_path):
     """Each exclusive test must not overlap in wall-clock time with any other test.
 
@@ -154,7 +163,7 @@ def test_exclusive_tests_run_alone(tmp_path):
 
     assert len(exclusive) >= EXPECTED_EXCLUSIVE_TESTS, (
         "Expected at least %d exclusive tests, found %d.\n"
-        "Check that suite_04–suite_05 exist and carry [Tags]    pabot:exclusive."
+        "Check that suite_04-suite_05 exist and carry [Tags]    pabot:exclusive."
         % (EXPECTED_EXCLUSIVE_TESTS, len(exclusive))
     )
 

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -13,7 +13,6 @@ def get_tmpdir_name(name):
 
 
 class TestVariables(unittest.TestCase):
-
     @classmethod
     def setUpClass(cls):
         cls.tmpdir = tempfile.mkdtemp()
@@ -27,7 +26,8 @@ class TestVariables(unittest.TestCase):
 
         cls.variables_suite = os.path.join(cls.suites_dir, "check_variables.robot")
         with open(cls.variables_suite, "w") as f:
-            f.write(textwrap.dedent("""
+            f.write(
+                textwrap.dedent("""
                 *** Test Cases ***
                 Test A
                     Log Variables
@@ -49,7 +49,8 @@ class TestVariables(unittest.TestCase):
                     Log    PABOTEXECUTIONBATCHSIZE=${PABOTEXECUTIONBATCHSIZE}
                     Log    PABOTNUMBEROFPROCESSES=${PABOTNUMBEROFPROCESSES}
                     Log    CALLER_ID=${CALLER_ID}
-            """))
+            """)
+            )
 
     @classmethod
     def tearDownClass(cls):
@@ -116,11 +117,17 @@ class TestVariables(unittest.TestCase):
         Checks that the expected pabot variables are set correctly in all test
         cases when there are more test cases than processes.
         """
-        process = self._run_pabot([
-            "--processes", "2", "--testlevelsplit",
-            self.variables_suite,
-        ])
-        assert process.returncode == 0, f"Pabot failed: {process.stdout}\n{process.stderr}"
+        process = self._run_pabot(
+            [
+                "--processes",
+                "2",
+                "--testlevelsplit",
+                self.variables_suite,
+            ]
+        )
+        assert (
+            process.returncode == 0
+        ), f"Pabot failed: {process.stdout}\n{process.stderr}"
 
         results = self._read_results()
         self.assertEqual(results["Test A"], "PASS")
@@ -132,28 +139,42 @@ class TestVariables(unittest.TestCase):
         self.assert_all_variables_present(variables)
         # Check the values of all variables are correct.
         pabotlib_uris = [test_vars["PABOTLIBURI"] for test_vars in variables.values()]
-        self.assertEqual(len(set(pabotlib_uris)), 1) # All should be the same
-        queue_indices = [test_vars["PABOTQUEUEINDEX"] for test_vars in variables.values()]
+        self.assertEqual(len(set(pabotlib_uris)), 1)  # All should be the same
+        queue_indices = [
+            test_vars["PABOTQUEUEINDEX"] for test_vars in variables.values()
+        ]
         self.assertListEqual(sorted(queue_indices), ["0", "1", "2", "3"])
-        pool_ids = [test_vars["PABOTEXECUTIONPOOLID"] for test_vars in variables.values()]
+        pool_ids = [
+            test_vars["PABOTEXECUTIONPOOLID"] for test_vars in variables.values()
+        ]
         self.assertListEqual(sorted(pool_ids), ["0", "0", "1", "1"])
-        batch_sizes = [test_vars["PABOTEXECUTIONBATCHSIZE"] for test_vars in variables.values()]
+        batch_sizes = [
+            test_vars["PABOTEXECUTIONBATCHSIZE"] for test_vars in variables.values()
+        ]
         self.assertListEqual(sorted(batch_sizes), ["4", "4", "4", "4"])
-        process_counts = [test_vars["PABOTNUMBEROFPROCESSES"] for test_vars in variables.values()]
+        process_counts = [
+            test_vars["PABOTNUMBEROFPROCESSES"] for test_vars in variables.values()
+        ]
         self.assertListEqual(sorted(process_counts), ["2", "2", "2", "2"])
         caller_ids = [test_vars["CALLER_ID"] for test_vars in variables.values()]
-        self.assertEqual(len(set(caller_ids)), 4) # All should be different
+        self.assertEqual(len(set(caller_ids)), 4)  # All should be different
 
     def test_check_variables_more_processes_than_tests(self):
         """
         Checks that the expected pabot variables are set correctly in all test
         cases when there are more processes than test cases.
         """
-        process = self._run_pabot([
-            "--processes", "8", "--testlevelsplit",
-            self.variables_suite,
-        ])
-        assert process.returncode == 0, f"Pabot failed: {process.stdout}\n{process.stderr}"
+        process = self._run_pabot(
+            [
+                "--processes",
+                "8",
+                "--testlevelsplit",
+                self.variables_suite,
+            ]
+        )
+        assert (
+            process.returncode == 0
+        ), f"Pabot failed: {process.stdout}\n{process.stderr}"
 
         results = self._read_results()
         self.assertEqual(results["Test A"], "PASS")
@@ -165,14 +186,22 @@ class TestVariables(unittest.TestCase):
         self.assert_all_variables_present(variables)
         # Check the values of all variables are correct.
         pabotlib_uris = [test_vars["PABOTLIBURI"] for test_vars in variables.values()]
-        self.assertEqual(len(set(pabotlib_uris)), 1) # All should be the same
-        queue_indices = [test_vars["PABOTQUEUEINDEX"] for test_vars in variables.values()]
+        self.assertEqual(len(set(pabotlib_uris)), 1)  # All should be the same
+        queue_indices = [
+            test_vars["PABOTQUEUEINDEX"] for test_vars in variables.values()
+        ]
         self.assertListEqual(sorted(queue_indices), ["0", "1", "2", "3"])
-        pool_ids = [test_vars["PABOTEXECUTIONPOOLID"] for test_vars in variables.values()]
+        pool_ids = [
+            test_vars["PABOTEXECUTIONPOOLID"] for test_vars in variables.values()
+        ]
         self.assertListEqual(sorted(pool_ids), ["0", "1", "2", "3"])
-        batch_sizes = [test_vars["PABOTEXECUTIONBATCHSIZE"] for test_vars in variables.values()]
+        batch_sizes = [
+            test_vars["PABOTEXECUTIONBATCHSIZE"] for test_vars in variables.values()
+        ]
         self.assertListEqual(sorted(batch_sizes), ["4", "4", "4", "4"])
-        process_counts = [test_vars["PABOTNUMBEROFPROCESSES"] for test_vars in variables.values()]
+        process_counts = [
+            test_vars["PABOTNUMBEROFPROCESSES"] for test_vars in variables.values()
+        ]
         self.assertListEqual(sorted(process_counts), ["8", "8", "8", "8"])
         caller_ids = [test_vars["CALLER_ID"] for test_vars in variables.values()]
-        self.assertEqual(len(set(caller_ids)), 4) # All should be different
+        self.assertEqual(len(set(caller_ids)), 4)  # All should be different


### PR DESCRIPTION
## Summary
This PR fixes issue #721, where executors were incorrectly numbered, which caused logging to suggest that the same executor might be running multiple tests at the same time.

In addition, the executor pool now always selects the smallest available executor from the currently free executors.

Apply automatic formatting also to couple of new test case files.

## Related issues
Fixes #721 

## Checklist
- [x] Tests added or updated
- [x] Documentation updated
- [x] Backwards compatibility considered
